### PR TITLE
Add manual widget refresh button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ The project contains three main targets:
 **Main App (SubscriberWidget)**
 - **MVVM pattern**: `ViewModel.swift` is the central view model that manages app state
 - **Services layer**: Protocol-based services for separation of concerns
-  - `YouTubeService`: Fetches channel data from YouTube Data API with caching (10-minute expiry)
+  - `YouTubeService`: Fetches channel data from YouTube Data API with caching (2-minute expiry)
   - `ChannelStorageService`: Persists channels and settings to shared UserDefaults
   - `AnalyticsService`: Mixpanel event tracking singleton
 - **Model**: Core data models in `Model/` directory
@@ -81,7 +81,7 @@ The project contains three main targets:
   - Channel search by name: `search?part=snippet&q={name}&type=channel`
   - Channel details by ID: `channels?part=snippet&id={id}`
   - Channel statistics: `channels?part=statistics&id={channelId}`
-- Caching: Uses the `Cache` library (Hyperoslo) with 600-second expiry for channel data
+- Caching: Uses the `Cache` library (Hyperoslo) with 120-second expiry for channel data
 - Response handling via generic `Response<T>` wrapper and custom error types in `SubWidgetError`
 
 ### Dependencies (Swift Package Manager)

--- a/SubscriberCount/Localizable.xcstrings
+++ b/SubscriberCount/Localizable.xcstrings
@@ -36,6 +36,24 @@
             "value" : "- पहले ऐप में एक चैनल जोड़ें, फिर एडिट करते समय इस विजेट पर टैप करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Tambahkan saluran di aplikasi, lalu ketuk widget ini saat mengedit"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- アプリにチャンネルを追加し、編集中にこのウィジェットをタップします"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Қолданбаға арна қосыңыз, содан кейін өңдеу кезінде осы виджетті түртіңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -48,34 +66,16 @@
             "value" : "- முதலில் செயலியில் ஒரு சேனலைச் சேர்க்கவும், பின்னர் திருத்தும் போது இந்த விட்ஜெட்டைத் தட்டவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "- アプリにチャンネルを追加し、編集中にこのウィジェットをタップします"
+            "value" : "- Uygulamaya bir kanal ekleyin ve ardından düzenleme yaparken bu widget'a dokunun"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "- 在应用程序中添加频道，然后在编辑时点击此小组件"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Қолданбаға арна қосыңыз, содан кейін өңдеу кезінде осы виджетті түртіңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Tambahkan saluran di aplikasi, lalu ketuk widget ini saat mengedit"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Uygulamaya bir kanal ekleyin ve ardından düzenleme yaparken bu widget'a dokunun"
           }
         }
       }
@@ -118,6 +118,24 @@
             "value" : "%1$@ ने %2$@ सब्सक्राइबर हासिल कर लिए!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ mencapai %2$@ subscriber!"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ が %2$@ 人の登録者に到達しました！"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ жазылушыға жетті!"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -130,34 +148,16 @@
             "value" : "%1$@ %2$@ சந்தாதாரர்களை எட்டியது!"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ が %2$@ 人の登録者に到達しました！"
+            "value" : "%1$@, %2$@ aboneye ulaştı!"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ 已达到 %2$@ 位订阅者！"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@ жазылушыға жетті!"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ mencapai %2$@ subscriber!"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@, %2$@ aboneye ulaştı!"
           }
         }
       }
@@ -194,6 +194,24 @@
             "value" : "1 घंटा"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 Jam"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1時間"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 сағат"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -206,34 +224,16 @@
             "value" : "1 மணி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1時間"
+            "value" : "1 Saat"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1小时"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 сағат"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 Jam"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 Saat"
           }
         }
       }
@@ -270,6 +270,24 @@
             "value" : "6 घंटे"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6 Jam"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6時間"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6 сағат"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -282,34 +300,16 @@
             "value" : "6 மணி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "6時間"
+            "value" : "6 Saat"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "6小时"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "6 сағат"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "6 Jam"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "6 Saat"
           }
         }
       }
@@ -346,6 +346,24 @@
             "value" : "12 घंटे"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 Jam"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12時間"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 сағат"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -358,34 +376,16 @@
             "value" : "12 மணி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12時間"
+            "value" : "12 Saat"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "12小时"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "12 сағат"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "12 Jam"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "12 Saat"
           }
         }
       }
@@ -422,6 +422,24 @@
             "value" : "30 मिनट"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 Menit"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30分"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 минут"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -434,34 +452,16 @@
             "value" : "30 நிமிடங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30分"
+            "value" : "30 Dakika"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "30分钟"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 минут"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 Menit"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 Dakika"
           }
         }
       }
@@ -498,6 +498,24 @@
             "value" : "ऐप में एक चैनल जोड़ें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan saluran di aplikasi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリにチャンネルを追加する"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қолданбаға арна қосыңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -510,34 +528,16 @@
             "value" : "செயலியில் ஒரு சேனலைச் சேர்க்கவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アプリにチャンネルを追加する"
+            "value" : "Uygulamaya bir kanal ekleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "在应用程序中添加频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қолданбаға арна қосыңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tambahkan saluran di aplikasi"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uygulamaya bir kanal ekleyin"
           }
         }
       }
@@ -575,6 +575,24 @@
             "value" : "वर्तमान में, आप अधिकतम 10 चैनल जोड़ सकते हैं। यदि आप और अधिक जोड़ना चाहते हैं, तो कृपया सेटिंग्स में दिए गए लिंक का उपयोग करके मुझसे संपर्क करें और मैं सीमा बढ़ा दूंगा।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saat ini, Anda dapat menambahkan hingga 10 saluran. Jika Anda ingin menambahkan lebih banyak, silakan hubungi saya menggunakan tautan di Pengaturan dan saya akan menambah batasnya."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在、最大 10 チャンネルを追加できます。さらに追加したい場合は、設定のリンクを使用して私にご連絡ください。制限を増やします。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қазіргі уақытта 10 арнаға дейін қосуға болады. Қосымша қосқыңыз келсе, \"Параметрлер\" бөліміндегі сілтеме арқылы маған хабарласыңыз, мен шектеуді арттырамын."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -587,34 +605,16 @@
             "value" : "தற்போது, நீங்கள் 10 சேனல்கள் வரை சேர்க்கலாம். நீங்கள் மேலும் சேர்க்க விரும்பினால், அமைப்புகளில் உள்ள இணைப்பைப் பயன்படுத்தி என்னை தொடர்பு கொள்ளவும், நான் வரம்பை அதிகரிக்கிறேன்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "現在、最大 10 チャンネルを追加できます。さらに追加したい場合は、設定のリンクを使用して私にご連絡ください。制限を増やします。"
+            "value" : "Şu anda en fazla 10 kanal ekleyebilirsiniz. Daha fazlasını eklemek isterseniz lütfen Ayarlar'daki bağlantıyı kullanarak benimle iletişime geçin; limiti artıracağım."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "目前，您最多可以添加 10 个频道。如果您想添加更多，请使用“设置”中的链接与我联系，我将增加限制。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қазіргі уақытта 10 арнаға дейін қосуға болады. Қосымша қосқыңыз келсе, \"Параметрлер\" бөліміндегі сілтеме арқылы маған хабарласыңыз, мен шектеуді арттырамын."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saat ini, Anda dapat menambahkan hingga 10 saluran. Jika Anda ingin menambahkan lebih banyak, silakan hubungi saya menggunakan tautan di Pengaturan dan saya akan menambah batasnya."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Şu anda en fazla 10 kanal ekleyebilirsiniz. Daha fazlasını eklemek isterseniz lütfen Ayarlar'daki bağlantıyı kullanarak benimle iletişime geçin; limiti artıracağım."
           }
         }
       }
@@ -651,6 +651,24 @@
             "value" : "सबसे पहले, अपनी लॉक स्क्रीन पर टैप करके रखें और 'कस्टमाइज़' पर टैप करें। फिर आप विजेट जोड़ सकते हैं और उसे टैप करके चैनल चुन सकते हैं।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pertama, ketuk dan tahan Layar Terkunci Anda dan ketuk 'Sesuaikan'. Kemudian Anda dapat menambahkan widget dan mengetuknya untuk memilih saluran."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まず、ロック画面を長押しして「カスタマイズ」をタップします。次に、ウィジェットを追加し、タップしてチャンネルを選択します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Алдымен құлыптау экранын түртіп, ұстап тұрыңыз және «Реттеу» түймесін түртіңіз. Содан кейін виджетті қосып, арнаны таңдау үшін оны түртуге болады."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -663,34 +681,16 @@
             "value" : "முதலில், உங்கள் பூட்டு திரையில் தட்டி அழுத்தி 'விருப்பமைக்கவும்' என்று தட்டவும். பின்னர் நீங்கள் விஜெட்டைச் சேர்க்கலாம் மற்றும் சேனலைத் தெரிவு செய்ய அதை தட்டலாம்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "まず、ロック画面を長押しして「カスタマイズ」をタップします。次に、ウィジェットを追加し、タップしてチャンネルを選択します。"
+            "value" : "Öncelikle Kilit Ekranınıza dokunup basılı tutun ve 'Özelleştir'e dokunun. Daha sonra widget'ı ekleyebilir ve kanalı seçmek için ona dokunabilirsiniz."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "首先，点击并按住锁定屏幕，然后点击“自定义”。然后您可以添加小组件并点击它来选择频道。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Алдымен құлыптау экранын түртіп, ұстап тұрыңыз және «Реттеу» түймесін түртіңіз. Содан кейін виджетті қосып, арнаны таңдау үшін оны түртуге болады."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pertama, ketuk dan tahan Layar Terkunci Anda dan ketuk 'Sesuaikan'. Kemudian Anda dapat menambahkan widget dan mengetuknya untuk memilih saluran."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öncelikle Kilit Ekranınıza dokunup basılı tutun ve 'Özelleştir'e dokunun. Daha sonra widget'ı ekleyebilir ve kanalı seçmek için ona dokunabilirsiniz."
           }
         }
       }
@@ -727,6 +727,24 @@
             "value" : "इस विजेट का उपयोग करने के लिए SubWidget Pro प्राप्त करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dapatkan SubWidget Pro untuk menggunakan widget ini"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このウィジェットを使うには SubWidget Pro が必要です"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бұл виджетті пайдалану үшін SubWidget Pro қажет"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -739,34 +757,16 @@
             "value" : "இந்த விட்ஜெட்டை பயன்படுத்த SubWidget Pro ஐப் பெறுங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このウィジェットを使うには SubWidget Pro が必要です"
+            "value" : "Bu widget'ı kullanmak için SubWidget Pro gerekir"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用此小组件需要 SubWidget Pro"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Бұл виджетті пайдалану үшін SubWidget Pro қажет"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dapatkan SubWidget Pro untuk menggunakan widget ini"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu widget'ı kullanmak için SubWidget Pro gerekir"
           }
         }
       }
@@ -815,6 +815,24 @@
             "value" : "दबाकर रखें, फिर 'एडिट विजेट' पर टैप करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tahan dan ketuk 'Edit Widget'"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長押しして「ウィジェットを編集」をタップします"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"Виджетті өңдеу\" түймесін басып тұрыңыз және түртіңіз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -827,34 +845,16 @@
             "value" : "அழுத்திப் பிடித்து, பின்னர் 'விட்ஜெட்டைத் திருத்து' என்பதைத் தட்டவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "長押しして「ウィジェットを編集」をタップします"
+            "value" : "Basılı tutun ve 'Widget'ı Düzenle'ye dokunun"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "按住并点击“编辑小组件”"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"Виджетті өңдеу\" түймесін басып тұрыңыз және түртіңіз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tahan dan ketuk 'Edit Widget'"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basılı tutun ve 'Widget'ı Düzenle'ye dokunun"
           }
         }
       }
@@ -891,6 +891,24 @@
             "value" : "मैं अपनी होमस्क्रीन पर विजेट कैसे जोड़ूं?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagaimana cara menambahkan widget ke layar beranda saya?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム画面にウィジェットを追加するにはどうすればよいですか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджетті негізгі экранға қалай қосуға болады?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -903,34 +921,16 @@
             "value" : "என் முகப்புத் திரையில் விஜெட்டை எப்படி சேர்க்கலாம்?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ホーム画面にウィジェットを追加するにはどうすればよいですか?"
+            "value" : "Widget'ı ana ekranıma nasıl eklerim?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "如何将小组件添加到我的主屏幕？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджетті негізгі экранға қалай қосуға болады?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bagaimana cara menambahkan widget ke layar beranda saya?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget'ı ana ekranıma nasıl eklerim?"
           }
         }
       }
@@ -967,6 +967,24 @@
             "value" : "मैं अपनी लॉक स्क्रीन पर विजेट कैसे जोड़ूं?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagaimana cara menambahkan widget ke Layar Terkunci saya?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロック画面にウィジェットを追加するにはどうすればよいですか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Құлыптау экранына виджетті қалай қосуға болады?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -979,34 +997,16 @@
             "value" : "என் பூட்டு திரையில் விஜெட்டை எப்படி சேர்க்கலாம்?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ロック画面にウィジェットを追加するにはどうすればよいですか?"
+            "value" : "Kilit Ekranıma nasıl widget eklerim?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "如何将小组件添加到我的锁定屏幕？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Құлыптау экранына виджетті қалай қосуға болады?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bagaimana cara menambahkan widget ke Layar Terkunci saya?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kilit Ekranıma nasıl widget eklerim?"
           }
         }
       }
@@ -1043,6 +1043,24 @@
             "value" : "मैं किसी चैनल को कैसे हटाऊँ?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagaimana cara menghapus saluran?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを削除するにはどうすればよいですか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арнаны қалай жоюға болады?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1055,34 +1073,16 @@
             "value" : "ஒரு சேனலை எப்படி நீக்குவது?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを削除するにはどうすればよいですか?"
+            "value" : "Bir kanalı nasıl silerim?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "如何删除频道？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арнаны қалай жоюға болады?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bagaimana cara menghapus saluran?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bir kanalı nasıl silerim?"
           }
         }
       }
@@ -1119,6 +1119,24 @@
             "value" : "मैं कितने चैनल जोड़ सकता हूँ?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berapa banyak saluran yang dapat saya tambahkan?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルは何個まで追加できますか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қанша арна қосуға болады?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1131,34 +1149,16 @@
             "value" : "நான் எத்தனை சேனல்களை சேர்க்கலாம்?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルは何個まで追加できますか?"
+            "value" : "Kaç kanal ekleyebilirim?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "我可以添加多少个频道？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қанша арна қосуға болады?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berapa banyak saluran yang dapat saya tambahkan?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaç kanal ekleyebilirim?"
           }
         }
       }
@@ -1195,6 +1195,24 @@
             "value" : "सब्सक्राइबर काउंट कितनी बार अपडेट होता है?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seberapa sering pembaruan jumlah pelanggan?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネル登録者数はどのくらいの頻度で更新されますか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жазылушылар саны қаншалықты жиі жаңартылады?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1207,34 +1225,16 @@
             "value" : "சந்தாதாரர் எண்ணிக்கை எவ்வளவு அடிக்கடி புதுப்பிக்கப்படுகிறது?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネル登録者数はどのくらいの頻度で更新されますか?"
+            "value" : "Abone sayısı ne sıklıkla güncellenir?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "订阅者数量多久更新一次？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жазылушылар саны қаншалықты жиі жаңартылады?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seberapa sering pembaruan jumlah pelanggan?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abone sayısı ne sıklıkla güncellenir?"
           }
         }
       }
@@ -1271,6 +1271,24 @@
             "value" : "मुझे अपना चैनल नहीं मिल रहा है।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saya tidak dapat menemukan saluran saya."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自分のチャンネルが見つかりません。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Мен өз арнамды таба алмаймын."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1283,34 +1301,16 @@
             "value" : "எனது சேனலை கண்டுபிடிக்க முடியவில்லை."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自分のチャンネルが見つかりません。"
+            "value" : "Kanalımı bulamıyorum."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "我找不到我的频道。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Мен өз арнамды таба алмаймын."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saya tidak dapat menemukan saluran saya."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanalımı bulamıyorum."
           }
         }
       }
@@ -1347,6 +1347,24 @@
             "value" : "मेरे पास एक फीचर आइडिया है जिसे मैं अनुरोध करना चाहता हूँ।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saya punya ide fitur yang ingin saya minta."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストしたい機能のアイデアがあります。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Менде сұрағым келетін мүмкіндік идеясы бар."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1359,34 +1377,16 @@
             "value" : "நான் கேட்க விரும்பும் ஒரு அம்ச யோசனை உள்ளது."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リクエストしたい機能のアイデアがあります。"
+            "value" : "Talep etmek istediğim bir özellik fikrim var."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "我有一个想要请求的功能想法。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Менде сұрағым келетін мүмкіндік идеясы бар."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saya punya ide fitur yang ingin saya minta."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Talep etmek istediğim bir özellik fikrim var."
           }
         }
       }
@@ -1429,6 +1429,24 @@
             "value" : "माइलस्टोन हासिल हुआ!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tonggak Pencapaian Tercapai!"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マイルストーンに到達しました!"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Белгіленген межеге жетті!"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1441,34 +1459,16 @@
             "value" : "மைல்கல் எட்டப்பட்டது!"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "マイルストーンに到達しました!"
+            "value" : "Kilometre Taşına Ulaşıldı!"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "里程碑已达！"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Белгіленген межеге жетті!"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tonggak Pencapaian Tercapai!"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kilometre Taşına Ulaşıldı!"
           }
         }
       }
@@ -1505,6 +1505,24 @@
             "value" : "मेरा सवाल यहां सूचीबद्ध नहीं है।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pertanyaan saya tidak tercantum di sini."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私の質問はここには記載されていません。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Менің сұрағым мұнда тізімде жоқ."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1517,34 +1535,16 @@
             "value" : "என் கேள்வி இங்கே பட்டியலிடப்படவில்லை."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "私の質問はここには記載されていません。"
+            "value" : "Sorum burada listelenmiyor."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "我的问题没有在这里列出。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Менің сұрағым мұнда тізімде жоқ."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pertanyaan saya tidak tercantum di sini."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sorum burada listelenmiyor."
           }
         }
       }
@@ -1581,6 +1581,24 @@
             "value" : "सेटिंग्स स्क्रीन से मुझसे संपर्क करें, मैं आपके किसी भी सवाल का जवाब दूंगा। मैं आमतौर पर कुछ घंटों के भीतर जवाब देता हूं!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Silakan hubungi saya dari layar pengaturan dan saya akan menjawab pertanyaan apa pun yang Anda miliki. Saya biasanya merespons dalam beberapa jam!."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定画面よりご連絡いただければ質問にお答えします。通常、数時間以内に返信します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Параметрлер экранынан маған хабарласыңыз, мен кез келген сұрағыңызға жауап беремін. Мен әдетте бірнеше сағат ішінде жауап беремін!."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1593,34 +1611,16 @@
             "value" : "அமைப்புகள் திரையிலிருந்து என்னை தொடர்பு கொள்ளுங்கள்; உங்களிடம் உள்ள எந்தக் கேள்விக்கும் நான் பதில் அளிப்பேன். பொதுவாக சில மணி நேரங்களுக்குள் பதிலளிக்கிறேன்!"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "設定画面よりご連絡いただければ質問にお答えします。通常、数時間以内に返信します。"
+            "value" : "Lütfen ayarlar ekranından benimle iletişime geçin, sorularınızı yanıtlayacağım. Genellikle birkaç saat içinde yanıt veririm!"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "请从设置屏幕与我联系，我将回答您的任何问题。我通常会在几个小时内回复！"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Параметрлер экранынан маған хабарласыңыз, мен кез келген сұрағыңызға жауап беремін. Мен әдетте бірнеше сағат ішінде жауап беремін!."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Silakan hubungi saya dari layar pengaturan dan saya akan menjawab pertanyaan apa pun yang Anda miliki. Saya biasanya merespons dalam beberapa jam!."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lütfen ayarlar ekranından benimle iletişime geçin, sorularınızı yanıtlayacağım. Genellikle birkaç saat içinde yanıt veririm!"
           }
         }
       }
@@ -1657,6 +1657,24 @@
             "value" : "कृपया अपनी होमस्क्रीन से विजेट को हटा दें और उसे फिर से जोड़ें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Harap hapus widget dari layar beranda Anda dan tambahkan kembali."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム画面からウィジェットを削除し、再度追加してください。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджетті негізгі экраннан алып тастап, қайта қосыңыз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1669,10 +1687,10 @@
             "value" : "தயவுசெய்து உங்கள் முகப்புத் திரையிலிருந்து விஜெட்டை நீக்கி மீண்டும் சேர்க்கவும்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ホーム画面からウィジェットを削除し、再度追加してください。"
+            "value" : "Lütfen widget'ı ana ekranınızdan kaldırın ve tekrar ekleyin."
           }
         },
         "zh-Hans" : {
@@ -1680,23 +1698,157 @@
             "state" : "translated",
             "value" : "请从主屏幕中删除该小组件并将其添加回来。"
           }
-        },
-        "kk" : {
+        }
+      }
+    },
+    "Refresh Widget" : {
+      "localizations" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Виджетті негізгі экраннан алып тастап, қайта қосыңыз."
+            "value" : "تحديث الأداة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget aktualisieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar widget"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualiser le widget"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विजेट रीफ्रेश करें"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Harap hapus widget dari layar beranda Anda dan tambahkan kembali."
+            "value" : "Segarkan Widget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットを更新"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджетті жаңарту"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atualizar widget"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "விட்ஜெட்டை புதுப்பிக்கவும்"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lütfen widget'ı ana ekranınızdan kaldırın ve tekrar ekleyin."
+            "value" : "Widget'i Yenile"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新小组件"
+          }
+        }
+      }
+    },
+    "Refreshes the widget timeline." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يُحدّث الجدول الزمني للأداة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualisiert die Widget-Zeitleiste."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualiza la línea de tiempo del widget."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualise la chronologie du widget."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विजेट की टाइमलाइन को रीफ्रेश करता है।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menyegarkan linimasa widget."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットのタイムラインを更新します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджеттің уақыт шкаласын жаңартады."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atualiza a linha do tempo do widget."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "விட்ஜெட்டின் காலவரிசையை புதுப்பிக்கும்."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget zaman akışını yeniler."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新小组件时间线。"
           }
         }
       }
@@ -1733,6 +1885,24 @@
             "value" : "विजेट के रंग डिफ़ॉल्ट पर वापस कर देता है - लाइट मोड में सफेद और डार्क मोड में काला।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengembalikan warna widget ke default - Putih dalam mode terang dan hitam dalam mode gelap."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットの色をデフォルト (ライト モードでは白、ダーク モードでは黒) に戻します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджет түстерін әдепкі мәндерге қалпына келтіреді - жарық режимінде ақ және қараңғы режимде қара."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1745,34 +1915,16 @@
             "value" : "விட்ஜெட்டின் நிறங்களை இயல்புநிலைக்கு மீட்டமைக்கும் - ஒளி முறையில் வெள்ளை, இருள் முறையில் கருப்பு."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ウィジェットの色をデフォルト (ライト モードでは白、ダーク モードでは黒) に戻します。"
+            "value" : "Widget'ın renklerini varsayılan ayarlara geri yükler - Açık modda beyaz ve karanlık modda siyah."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "将小组件的颜色恢复为默认值 - 浅色模式下为白色，深色模式下为黑色。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджет түстерін әдепкі мәндерге қалпына келтіреді - жарық режимінде ақ және қараңғы режимде қара."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mengembalikan warna widget ke default - Putih dalam mode terang dan hitam dalam mode gelap."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget'ın renklerini varsayılan ayarlara geri yükler - Açık modda beyaz ve karanlık modda siyah."
           }
         }
       }
@@ -1810,6 +1962,24 @@
             "value" : "विजेट के रंगों को डिफ़ॉल्ट में पुनर्स्थापित करता है।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengembalikan warna widget ke default."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットの色をデフォルトに戻します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджет түстерін әдепкі мәндерге қалпына келтіреді."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1822,34 +1992,16 @@
             "value" : "விஜெட்டின் நிறங்களை இயல்புநிலைக்கு மீட்டமைக்கிறது."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ウィジェットの色をデフォルトに戻します。"
+            "value" : "Widget'ın renklerini varsayılanlara geri yükler."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "将小组件的颜色恢复为默认值。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджет түстерін әдепкі мәндерге қалпына келтіреді."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mengembalikan warna widget ke default."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget'ın renklerini varsayılanlara geri yükler."
           }
         }
       }
@@ -1886,6 +2038,24 @@
             "value" : "अपना चैनल चुनें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih Saluran Anda"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを選択してください"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арнаңызды таңдаңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1898,34 +2068,16 @@
             "value" : "உங்கள் சேனலைத் தெரிவு செய்க"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを選択してください"
+            "value" : "Kanalınızı Seçin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择您的频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арнаңызды таңдаңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pilih Saluran Anda"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanalınızı Seçin"
           }
         }
       }
@@ -1962,6 +2114,24 @@
             "value" : "सब्सक्राइबर काउंट"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah Subscriber"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登録者数"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жазылушылар саны"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1974,34 +2144,16 @@
             "value" : "சந்தாதாரர் எண்ணிக்கை"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "登録者数"
+            "value" : "Abone Sayısı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "订阅者数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жазылушылар саны"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jumlah Subscriber"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abone Sayısı"
           }
         }
       }
@@ -2038,6 +2190,24 @@
             "value" : "सब्सक्राइबर + व्यूज़"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subscriber + Tayangan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登録者数 + 視聴回数"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жазылушылар + қаралымдар"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2050,34 +2220,16 @@
             "value" : "சந்தாதாரர்கள் + பார்வைகள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "登録者数 + 視聴回数"
+            "value" : "Aboneler + Görüntülemeler"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "订阅者数 + 观看次数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жазылушылар + қаралымдар"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Subscriber + Tayangan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aboneler + Görüntülemeler"
           }
         }
       }
@@ -2114,6 +2266,24 @@
             "value" : "चैनल को हटाने के लिए उस पर दाईं ओर स्वाइप करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geser ke kanan pada saluran untuk menghapusnya"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを右にスワイプして削除します"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оны жою үшін арнаны оңға сырғытыңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2126,34 +2296,16 @@
             "value" : "சேனலை நீக்க அதில் வலமாக ஸ்வைப் செய்யவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを右にスワイプして削除します"
+            "value" : "Silmek için kanalı sağa kaydırın"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "向右滑动频道即可将其删除"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Оны жою үшін арнаны оңға сырғытыңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geser ke kanan pada saluran untuk menghapusnya"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Silmek için kanalı sağa kaydırın"
           }
         }
       }
@@ -2190,6 +2342,24 @@
             "value" : "अपनी होमस्क्रीन पर कहीं भी टैप करके रखें और ऊपर बाईं ओर प्लस बटन पर टैप करें। SubWidget को खोजें और उसे अपनी होमस्क्रीन पर जोड़ें। अंत में, विजेट पर टैप करके रखें और अपना चैनल चुनें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk dan tahan di mana saja di layar beranda Anda dan ketuk tombol plus di kiri atas. Cari SubWidget dan tambahkan ke layar beranda Anda. Terakhir, ketuk dan tahan widget dan pilih saluran Anda."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム画面の任意の場所を長押しし、左上のプラスボタンをタップします。 SubWidget を探してホーム画面に追加します。最後に、ウィジェットを長押ししてチャンネルを選択します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Негізгі экранның кез келген жерін түртіп, ұстап тұрыңыз және жоғарғы сол жақтағы қосу түймесін түртіңіз. SubWidget іздеп, оны негізгі экранға қосыңыз. Соңында виджетті түртіп, ұстап тұрыңыз және арнаңызды таңдаңыз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2202,34 +2372,16 @@
             "value" : "உங்கள் முகப்புத் திரையில் எங்கும் தட்டி அழுத்தி, மேல் இடதுபுறத்தில் உள்ள பிளஸ் பட்டனை தட்டவும். SubWidget ஐத் தேடி உங்கள் முகப்புத் திரையில் சேர்க்கவும். இறுதியாக, விஜெட்டின் மீது தட்டி அழுத்தி உங்கள் சேனலைத் தெரிவு செய்க."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ホーム画面の任意の場所を長押しし、左上のプラスボタンをタップします。 SubWidget を探してホーム画面に追加します。最後に、ウィジェットを長押ししてチャンネルを選択します。"
+            "value" : "Ana ekranınızda herhangi bir yere dokunup basılı tutun ve sol üstteki artı düğmesine dokunun. SubWidget'i arayın ve ana ekranınıza ekleyin. Son olarak widget'a dokunup basılı tutun ve kanalınızı seçin."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "点击并按住主屏幕上的任意位置，然后点击左上角的加号按钮。查找 SubWidget 并将其添加到您的主屏幕。最后，点击并按住小组件并选择您的频道。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Негізгі экранның кез келген жерін түртіп, ұстап тұрыңыз және жоғарғы сол жақтағы қосу түймесін түртіңіз. SubWidget іздеп, оны негізгі экранға қосыңыз. Соңында виджетті түртіп, ұстап тұрыңыз және арнаңызды таңдаңыз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ketuk dan tahan di mana saja di layar beranda Anda dan ketuk tombol plus di kiri atas. Cari SubWidget dan tambahkan ke layar beranda Anda. Terakhir, ketuk dan tahan widget dan pilih saluran Anda."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ana ekranınızda herhangi bir yere dokunup basılı tutun ve sol üstteki artı düğmesine dokunun. SubWidget'i arayın ve ana ekranınıza ekleyin. Son olarak widget'a dokunup basılı tutun ve kanalınızı seçin."
           }
         }
       }
@@ -2266,6 +2418,24 @@
             "value" : "चैनल लोड नहीं हो रहे हैं।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saluran tidak dimuat."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルが読み込まれていません。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арналар жүктелмейді."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2278,34 +2448,16 @@
             "value" : "சேனல்கள் ஏற்றப்படவில்லை."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルが読み込まれていません。"
+            "value" : "Kanallar yüklenmiyor."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "频道未加载。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арналар жүктелмейді."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saluran tidak dimuat."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanallar yüklenmiyor."
           }
         }
       }
@@ -2342,6 +2494,24 @@
             "value" : "विजेट खाली है।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widgetnya kosong."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットは空白です。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджет бос."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2354,34 +2524,16 @@
             "value" : "விஜெட்டு காலியாக உள்ளது."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ウィジェットは空白です。"
+            "value" : "Widget boş."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "小组件是空白的。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджет бос."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widgetnya kosong."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget boş."
           }
         }
       }
@@ -2418,6 +2570,24 @@
             "value" : "यह एक सर्वर समस्या को दर्शाता है। कृपया बाद में पुनः प्रयास करें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ini menunjukkan masalah server. Silakan coba lagi nanti."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "これはサーバーの問題を示しています。後でもう一度試してください。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бұл сервер мәселесін көрсетеді. Тағы жасауды сәл кейінірек көріңізді өтінеміз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2430,34 +2600,16 @@
             "value" : "இது ஒரு சேவையக சிக்கலை குறிக்கிறது. தயவுசெய்து பின்னர் முயற்சிக்கவும்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "これはサーバーの問題を示しています。後でもう一度試してください。"
+            "value" : "Bu bir sunucu sorununu gösterir. Lütfen daha sonra tekrar deneyin."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "这表明服务器有问题。请稍后重试。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Бұл сервер мәселесін көрсетеді. Тағы жасауды сәл кейінірек көріңізді өтінеміз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ini menunjukkan masalah server. Silakan coba lagi nanti."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu bir sunucu sorununu gösterir. Lütfen daha sonra tekrar deneyin."
           }
         }
       }
@@ -2494,6 +2646,24 @@
             "value" : "कुल सब्सक्राइबर"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah subscriber"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "総登録者数"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жалпы жазылушылар саны"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2506,34 +2676,16 @@
             "value" : "மொத்த சந்தாதாரர்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "総登録者数"
+            "value" : "Toplam abone sayısı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "订阅者总数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жалпы жазылушылар саны"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jumlah subscriber"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toplam abone sayısı"
           }
         }
       }
@@ -2570,6 +2722,24 @@
             "value" : "कुल दृश्य"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah tayangan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "総視聴回数"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жалпы қаралым саны"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2582,34 +2752,16 @@
             "value" : "மொத்த காட்சிகள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "総視聴回数"
+            "value" : "Toplam görüntüleme sayısı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "总观看次数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жалпы қаралым саны"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jumlah tayangan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toplam görüntüleme sayısı"
           }
         }
       }
@@ -2646,6 +2798,24 @@
             "value" : "अपने चैनल के नाम के बजाय अपनी चैनल आईडी दर्ज करने का प्रयास करें। यदि वह अभी भी काम नहीं करता है, तो कृपया मुझसे संपर्क करें और मैं आपकी मदद करूंगा।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coba masukkan ID saluran Anda, bukan nama saluran Anda. Jika masih tidak berhasil, silakan hubungi saya dan saya akan membantu Anda."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネル名の代わりにチャンネル ID を入力してみてください。それでもうまくいかない場合は、私に連絡してください。お手伝いします。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арна атауының орнына арна идентификаторын енгізіп көріңіз. Егер бұл әлі жұмыс істемесе, маған хабарласыңыз, мен сізге көмектесемін."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2658,34 +2828,16 @@
             "value" : "உங்கள் சேனல் பெயருக்கு பதிலாக உங்கள் சேனல் ஐடியை உள்ளிட முயற்சிக்கவும். அதுவும் செயல்படவில்லை என்றால், தயவுசெய்து என்னை தொடர்பு கொள்ளவும், நான் உதவுவேன்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネル名の代わりにチャンネル ID を入力してみてください。それでもうまくいかない場合は、私に連絡してください。お手伝いします。"
+            "value" : "Kanal adınız yerine kanal kimliğinizi girmeyi deneyin. Eğer hala işe yaramazsa lütfen benimle iletişime geçin, size yardımcı olacağım."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "尝试输入您的频道 ID 而不是频道名称。如果仍然不行，请联系我，我会帮助你。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арна атауының орнына арна идентификаторын енгізіп көріңіз. Егер бұл әлі жұмыс істемесе, маған хабарласыңыз, мен сізге көмектесемін."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coba masukkan ID saluran Anda, bukan nama saluran Anda. Jika masih tidak berhasil, silakan hubungi saya dan saya akan membantu Anda."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanal adınız yerine kanal kimliğinizi girmeyi deneyin. Eğer hala işe yaramazsa lütfen benimle iletişime geçin, size yardımcı olacağım."
           }
         }
       }
@@ -2722,6 +2874,24 @@
             "value" : "दुर्भाग्यवश, YouTube सटीक सब्सक्राइबर गिनती प्रदान नहीं करता है, वे एक गोल नंबर प्रदान करते हैं।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sayangnya YouTube tidak memberikan jumlah pasti subscribernya, mereka memberikan angka yang dibulatkan."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "残念ながら、YouTube は正確な登録者数を提供しておらず、概数を提供しています。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Өкінішке орай, YouTube жазылушылардың нақты санын бермейді, олар дөңгелектелген нөмірді береді."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2734,34 +2904,16 @@
             "value" : "துரதிருஷ்டவசமாக, YouTube குறிப்பிட்ட சந்தாதாரர் எண்ணிக்கையை வழங்காமல், ஒரு சுற்று எண்ணை வழங்குகிறது."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "残念ながら、YouTube は正確な登録者数を提供しておらず、概数を提供しています。"
+            "value" : "Ne yazık ki YouTube tam abone sayısını vermiyor; yuvarlatılmış bir sayı veriyor."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "不幸的是，YouTube 不提供准确的订阅者数量，他们提供的是四舍五入的数字。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Өкінішке орай, YouTube жазылушылардың нақты санын бермейді, олар дөңгелектелген нөмірді береді."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sayangnya YouTube tidak memberikan jumlah pasti subscribernya, mereka memberikan angka yang dibulatkan."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ne yazık ki YouTube tam abone sayısını vermiyor; yuvarlatılmış bir sayı veriyor."
           }
         }
       }
@@ -2798,6 +2950,24 @@
             "value" : "अनलॉक करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka kunci"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロックを解除する"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Құлыпты ашу"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2810,34 +2980,16 @@
             "value" : "திற"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ロックを解除する"
+            "value" : "Kilidi aç"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "解锁"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Құлыпты ашу"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buka kunci"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kilidi aç"
           }
         }
       }
@@ -2874,6 +3026,24 @@
             "value" : "एक ही विजेट में अपने सब्सक्राइबर और व्यू की संख्या देखें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lihat jumlah subscriber dan tayangan dalam satu widget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1つのウィジェットで登録者数と視聴回数をまとめて表示"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бір виджетте жазылушылар мен қаралым санын бірге көріңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2886,34 +3056,16 @@
             "value" : "ஒரே விட்ஜெட்டில் உங்கள் சந்தாதாரர்கள் மற்றும் பார்வைகள் எண்ணிக்கையை காணுங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1つのウィジェットで登録者数と視聴回数をまとめて表示"
+            "value" : "Abone ve görüntülenme sayılarını tek bir widget'ta birlikte görüntüleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "在一个小组件中同时查看订阅者数和观看次数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Бір виджетте жазылушылар мен қаралым санын бірге көріңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lihat jumlah subscriber dan tayangan dalam satu widget"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abone ve görüntülenme sayılarını tek bir widget'ta birlikte görüntüleyin"
           }
         }
       }
@@ -2950,6 +3102,24 @@
             "value" : "दृश्य गणना"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah Tayangan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視聴回数"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қаралым саны"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2962,34 +3132,16 @@
             "value" : "காட்சி எண்ணிக்கை"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "視聴回数"
+            "value" : "Görüntülenme Sayısı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "观看次数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қаралым саны"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jumlah Tayangan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Görüntülenme Sayısı"
           }
         }
       }
@@ -3026,6 +3178,24 @@
             "value" : "अपनी YouTube सब्सक्राइबर गिनती को रियलटाइम में देखें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lihat jumlah subscriber YouTube Anda secara real time"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube の登録者数をリアルタイムで表示"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube жазылушылар санын нақты уақытта көріңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3038,34 +3208,16 @@
             "value" : "உங்கள் YouTube சந்தாதாரர் எண்ணிக்கையை நேரடியாக காண்க"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "YouTube の登録者数をリアルタイムで表示"
+            "value" : "YouTube abone sayınızı gerçek zamanlı görüntüleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "实时查看你的 YouTube 订阅者数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YouTube жазылушылар санын нақты уақытта көріңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lihat jumlah subscriber YouTube Anda secara real time"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YouTube abone sayınızı gerçek zamanlı görüntüleyin"
           }
         }
       }
@@ -3102,6 +3254,24 @@
             "value" : "अपनी YouTube दृश्य गणना को रियलटाइम में देखें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lihat jumlah tayangan YouTube Anda secara real time"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube の視聴回数をリアルタイムで表示"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube қаралым санын нақты уақытта көріңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3114,34 +3284,16 @@
             "value" : "உங்கள் YouTube காட்சி எண்ணிக்கையை நேரடியாக காண்க"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "YouTube の視聴回数をリアルタイムで表示"
+            "value" : "YouTube görüntülenme sayınızı gerçek zamanlı görüntüleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "实时查看你的 YouTube 观看次数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YouTube қаралым санын нақты уақытта көріңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lihat jumlah tayangan YouTube Anda secara real time"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YouTube görüntülenme sayınızı gerçek zamanlı görüntüleyin"
           }
         }
       }
@@ -3178,6 +3330,24 @@
             "value" : "रीसेट बटन क्या करता है?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apa fungsi tombol reset?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リセットボタンは何をするのですか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қалпына келтіру түймесі не істейді?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3190,34 +3360,16 @@
             "value" : "மீட்டமைப்பு பொத்தான் என்ன செய்கிறது?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リセットボタンは何をするのですか?"
+            "value" : "Sıfırlama düğmesi ne işe yarar?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置按钮有什么作用？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қалпына келтіру түймесі не істейді?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apa fungsi tombol reset?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sıfırlama düğmesi ne işe yarar?"
           }
         }
       }
@@ -3254,6 +3406,24 @@
             "value" : "यह सटीक सब्सक्राइबर गिनती क्यों नहीं दिखाता है?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengapa tidak menunjukkan jumlah pasti pelanggan?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正確なチャンネル登録者数が表示されないのはなぜですか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неліктен ол жазылушылардың нақты санын көрсетпейді?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3266,10 +3436,10 @@
             "value" : "ஏன் அது குறிப்பிட்ட சந்தாதாரர் எண்ணிக்கையை காட்டவில்லை?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正確なチャンネル登録者数が表示されないのはなぜですか?"
+            "value" : "Neden tam abone sayısını göstermiyor?"
           }
         },
         "zh-Hans" : {
@@ -3277,23 +3447,81 @@
             "state" : "translated",
             "value" : "为什么它不显示确切的订阅者数量？"
           }
-        },
-        "kk" : {
+        }
+      }
+    },
+    "Widget Kind" : {
+      "localizations" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Неліктен ол жазылушылардың нақты санын көрсетпейді?"
+            "value" : "نوع الأداة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget-Typ"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de widget"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type de widget"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विजेट प्रकार"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mengapa tidak menunjukkan jumlah pasti pelanggan?"
+            "value" : "Jenis Widget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットの種類"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджет түрі"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de widget"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "விட்ஜெட் வகை"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Neden tam abone sayısını göstermiyor?"
+            "value" : "Widget Türü"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小组件类型"
           }
         }
       }
@@ -3330,6 +3558,24 @@
             "value" : "SubWidget Pro के साथ, आप 10 तक चैनल जोड़ सकते हैं। यदि आप इससे अधिक जोड़ना चाहते हैं, तो सेटिंग्स में दिए गए लिंक से मुझसे संपर्क करें और मैं सीमा बढ़ा दूंगा।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dengan SubWidget Pro, Anda dapat menambahkan hingga 10 saluran. Jika Anda ingin menambahkan lebih banyak, silakan hubungi saya menggunakan tautan di Pengaturan dan saya akan menambah batasnya."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget Pro では、最大 10 チャンネルを追加できます。さらに追加したい場合は、設定のリンクを使用して私にご連絡ください。制限を増やします。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget Pro көмегімен 10 арнаға дейін қосуға болады. Қосымша қосқыңыз келсе, \"Параметрлер\" бөліміндегі сілтеме арқылы маған хабарласыңыз, мен шектеуді арттырамын."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3342,34 +3588,16 @@
             "value" : "SubWidget Pro உடன், நீங்கள் 10 சேனல்கள் வரை சேர்க்கலாம். அதற்கு மேல் சேர்க்க விரும்பினால், அமைப்புகளில் உள்ள இணைப்பைப் பயன்படுத்தி என்னை தொடர்பு கொள்ளுங்கள்; நான் வரம்பை உயர்த்துவேன்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "SubWidget Pro では、最大 10 チャンネルを追加できます。さらに追加したい場合は、設定のリンクを使用して私にご連絡ください。制限を増やします。"
+            "value" : "SubWidget Pro ile 10'a kadar kanal ekleyebilirsiniz. Daha fazlasını eklemek isterseniz lütfen Ayarlar'daki bağlantıyı kullanarak benimle iletişime geçin; limiti artıracağım."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用 SubWidget Pro，您最多可以添加 10 个频道。如果您想添加更多，请使用“设置”中的链接与我联系，我将增加限制。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget Pro көмегімен 10 арнаға дейін қосуға болады. Қосымша қосқыңыз келсе, \"Параметрлер\" бөліміндегі сілтеме арқылы маған хабарласыңыз, мен шектеуді арттырамын."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dengan SubWidget Pro, Anda dapat menambahkan hingga 10 saluran. Jika Anda ingin menambahkan lebih banyak, silakan hubungi saya menggunakan tautan di Pengaturan dan saya akan menambah batasnya."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget Pro ile 10'a kadar kanal ekleyebilirsiniz. Daha fazlasını eklemek isterseniz lütfen Ayarlar'daki bağlantıyı kullanarak benimle iletişime geçin; limiti artıracağım."
           }
         }
       }
@@ -3406,6 +3634,24 @@
             "value" : "आप नीचे दिए गए विशलिस्ट टैब का उपयोग करके एक फीचर का अनुरोध कर सकते हैं।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda dapat meminta fitur menggunakan tab Daftar Keinginan di bawah."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以下の「ウィッシュリスト」タブを使用して機能をリクエストできます。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Төмендегі Қалаулар тізімі қойындысын пайдаланып мүмкіндікті сұрауға болады."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3418,34 +3664,16 @@
             "value" : "நீங்கள் கீழே உள்ள Wishlist தாவலைப் பயன்படுத்தி ஒரு அம்சத்தை கோரலாம்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "以下の「ウィッシュリスト」タブを使用して機能をリクエストできます。"
+            "value" : "Aşağıdaki İstek Listesi sekmesini kullanarak bir özellik talep edebilirsiniz."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "您可以使用下面的“愿望清单”选项卡来请求某项功能。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Төмендегі Қалаулар тізімі қойындысын пайдаланып мүмкіндікті сұрауға болады."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anda dapat meminta fitur menggunakan tab Daftar Keinginan di bawah."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aşağıdaki İstek Listesi sekmesini kullanarak bir özellik talep edebilirsiniz."
           }
         }
       }
@@ -3482,6 +3710,24 @@
             "value" : "आप ऐप सेटिंग्स में विजेट को कितनी बार अपडेट करना चाहते हैं, यह चुन सकते हैं। न्यूनतम हर 30 मिनट है।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda dapat memilih seberapa sering Anda ingin widget diperbarui di pengaturan aplikasi. Minimalnya setiap 30 menit."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリ設定でウィジェットを更新する頻度を選択できます。最小値は 30 分ごとです。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджеттің қаншалықты жиі жаңартылатынын қолданба параметрлерінде таңдауға болады. Минималды - әр 30 минут сайын."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3494,34 +3740,16 @@
             "value" : "நீங்கள் செயலி அமைப்புகளில் விஜெட்டு எவ்வளவு அடிக்கடி புதுப்பிக்கப்பட வேண்டும் என்பதை தெரிவு செய்யலாம். குறைந்தபட்சம் ஒவ்வொரு 30 நிமிடங்களுக்கும் உள்ளது."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アプリ設定でウィジェットを更新する頻度を選択できます。最小値は 30 分ごとです。"
+            "value" : "Widget'ın ne sıklıkta güncellenmesini istediğinizi uygulama ayarlarından seçebilirsiniz. Minimum her 30 dakikada birdir."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "您可以在应用程序设置中选择小组件的更新频率。最少为每 30 分钟一次。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджеттің қаншалықты жиі жаңартылатынын қолданба параметрлерінде таңдауға болады. Минималды - әр 30 минут сайын."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anda dapat memilih seberapa sering Anda ingin widget diperbarui di pengaturan aplikasi. Minimalnya setiap 30 menit."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget'ın ne sıklıkta güncellenmesini istediğinizi uygulama ayarlarından seçebilirsiniz. Minimum her 30 dakikada birdir."
           }
         }
       }

--- a/SubscriberCount/RefreshWidgetIntent.swift
+++ b/SubscriberCount/RefreshWidgetIntent.swift
@@ -1,0 +1,46 @@
+//
+//  RefreshWidgetIntent.swift
+//  SubscriberWidget
+//
+//  Created by OpenAI on 2026-03-14.
+//
+
+import AppIntents
+import WidgetKit
+
+extension WidgetType {
+    var widgetKind: String {
+        switch self {
+        case .subscribers:
+            return "SubscriberCount"
+        case .views:
+            return "ViewCount"
+        case .combined:
+            return "CombinedCount"
+        }
+    }
+}
+
+struct RefreshWidgetIntent: AppIntent {
+    static var title: LocalizedStringResource = "Refresh Widget"
+    static var description = IntentDescription("Refreshes the widget timeline.")
+    static var openAppWhenRun = false
+    static var isDiscoverable = false
+
+    @Parameter(title: "Widget Kind")
+    var widgetKind: String
+
+    init() {
+        self.widgetKind = WidgetType.subscribers.widgetKind
+    }
+
+    init(widgetKind: String) {
+        self.widgetKind = widgetKind
+    }
+
+    func perform() async throws -> some IntentResult {
+        AnalyticsService.shared.logWidgetManualRefreshTapped(widgetKind: widgetKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: widgetKind)
+        return .result()
+    }
+}

--- a/SubscriberCount/Views/MediumWidget.swift
+++ b/SubscriberCount/Views/MediumWidget.swift
@@ -19,6 +19,8 @@ struct MediumWidget: View {
     @Environment(\.colorScheme) var colorScheme
 
     @AppStorage("showUpdateTime", store: .shared) var showUpdateTime: Bool = true
+    @AppStorage("showWidgetRefreshButton", store: .shared) var showWidgetRefreshButton: Bool = false
+    @AppStorage("hasProAccess", store: .shared) private var hasProAccess: Bool = false
     let lastUpdatedTime: String = .currentTime
 
     var channel: YouTubeChannel? {
@@ -62,6 +64,14 @@ struct MediumWidget: View {
 
     private var usesLocalPreviewImage: Bool {
         channel?.profileImage.hasPrefix("OnboardingAvatar-") == true
+    }
+
+    private var shouldShowRefreshButton: Bool {
+        guard hasProAccess else { return false }
+        guard showWidgetRefreshButton else { return false }
+        guard channel?.channelName != YouTubeChannel.preview.channelName else { return false }
+        guard let widgetType = entry?.widgetType else { return false }
+        return widgetType == .subscribers || widgetType == .views || widgetType == .combined
     }
 
     var body: some View {
@@ -127,8 +137,16 @@ struct MediumWidget: View {
                     Spacer()
 
                     VStack(alignment: .trailing) {
-                        YouTubeLogo()
-                            .frame(maxHeight: .infinity, alignment: .top)
+                        Group {
+                            if shouldShowRefreshButton {
+                                WidgetRefreshButton(
+                                    widgetType: entry.widgetType
+                                )
+                            } else {
+                                YouTubeLogo()
+                            }
+                        }
+                        .frame(maxHeight: .infinity, alignment: .top)
 
                         Text(lastUpdatedTime)
                             .font(.system(size: 11))

--- a/SubscriberCount/Views/MediumWidget.swift
+++ b/SubscriberCount/Views/MediumWidget.swift
@@ -70,8 +70,7 @@ struct MediumWidget: View {
         guard hasProAccess else { return false }
         guard showWidgetRefreshButton else { return false }
         guard channel?.channelName != YouTubeChannel.preview.channelName else { return false }
-        guard let widgetType = entry?.widgetType else { return false }
-        return widgetType == .subscribers || widgetType == .views || widgetType == .combined
+        return entry != nil
     }
 
     var body: some View {

--- a/SubscriberCount/Views/SmallWidget.swift
+++ b/SubscriberCount/Views/SmallWidget.swift
@@ -63,8 +63,7 @@ struct SmallWidget: View {
         guard hasProAccess else { return false }
         guard showWidgetRefreshButton else { return false }
         guard channel?.channelName != YouTubeChannel.preview.channelName else { return false }
-        guard let widgetType = entry?.widgetType else { return false }
-        return widgetType == .subscribers || widgetType == .views || widgetType == .combined
+        return entry != nil
     }
 
     var body: some View {

--- a/SubscriberCount/Views/SmallWidget.swift
+++ b/SubscriberCount/Views/SmallWidget.swift
@@ -16,6 +16,8 @@ struct SmallWidget: View {
     @Environment(\.widgetRenderingMode) var widgetRenderingMode
 
     @AppStorage("showUpdateTime", store: .shared) var showUpdateTime: Bool = true
+    @AppStorage("showWidgetRefreshButton", store: .shared) var showWidgetRefreshButton: Bool = false
+    @AppStorage("hasProAccess", store: .shared) private var hasProAccess: Bool = false
     let lastUpdatedTime: String = .currentTime
 
     var channel: YouTubeChannel? {
@@ -57,6 +59,14 @@ struct SmallWidget: View {
         channel?.profileImage.hasPrefix("OnboardingAvatar-") == true
     }
 
+    private var shouldShowRefreshButton: Bool {
+        guard hasProAccess else { return false }
+        guard showWidgetRefreshButton else { return false }
+        guard channel?.channelName != YouTubeChannel.preview.channelName else { return false }
+        guard let widgetType = entry?.widgetType else { return false }
+        return widgetType == .subscribers || widgetType == .views || widgetType == .combined
+    }
+
     var body: some View {
         ZStack {
             if let entry = entry,
@@ -85,7 +95,13 @@ struct SmallWidget: View {
                         Spacer()
 
                         VStack(alignment: .trailing, spacing: 6) {
-                            YouTubeLogo()
+                            if shouldShowRefreshButton {
+                                WidgetRefreshButton(
+                                    widgetType: entry.widgetType
+                                )
+                            } else {
+                                YouTubeLogo()
+                            }
                             Text(lastUpdatedTime)
                                 .font(.system(size: 10))
                                 .foregroundColor(accentColor)

--- a/SubscriberCount/Views/WidgetRefreshButton.swift
+++ b/SubscriberCount/Views/WidgetRefreshButton.swift
@@ -1,0 +1,23 @@
+//
+//  WidgetRefreshButton.swift
+//  SubscriberWidget
+//
+//  Created by OpenAI on 2026-03-14.
+//
+
+import SwiftUI
+import AppIntents
+
+struct WidgetRefreshButton: View {
+    let widgetType: WidgetType
+
+    var body: some View {
+        Button(intent: RefreshWidgetIntent(widgetKind: widgetType.widgetKind)) {
+            Image(systemName: "arrow.clockwise.circle.fill")
+                .font(.system(size: 20, weight: .bold))
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.white, Color.youtubeRed)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/SubscriberWidget/Localizable.xcstrings
+++ b/SubscriberWidget/Localizable.xcstrings
@@ -36,6 +36,24 @@
             "value" : "- पहले ऐप में एक चैनल जोड़ें, फिर एडिट करते समय इस विजेट पर टैप करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Tambahkan saluran di aplikasi, lalu ketuk widget ini saat mengedit"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- アプリにチャンネルを追加し、編集中にこのウィジェットをタップします"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Қолданбаға арна қосыңыз, содан кейін өңдеу кезінде осы виджетті түртіңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -48,34 +66,16 @@
             "value" : "- முதலில் செயலியில் ஒரு சேனலைச் சேர்க்கவும், பின்னர் திருத்தும் போது இந்த விட்ஜெட்டைத் தட்டவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "- アプリにチャンネルを追加し、編集中にこのウィジェットをタップします"
+            "value" : "- Uygulamaya bir kanal ekleyin ve ardından düzenleme yaparken bu widget'a dokunun"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "- 在应用程序中添加频道，然后在编辑时点击此小组件"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Қолданбаға арна қосыңыз, содан кейін өңдеу кезінде осы виджетті түртіңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Tambahkan saluran di aplikasi, lalu ketuk widget ini saat mengedit"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Uygulamaya bir kanal ekleyin ve ardından düzenleme yaparken bu widget'a dokunun"
           }
         }
       }
@@ -112,6 +112,24 @@
             "value" : "@mkbhd"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "@mkbhd"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "@mkbhd"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "@mkbhd"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -124,31 +142,13 @@
             "value" : "@mkbhd"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "@mkbhd"
           }
         },
         "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "@mkbhd"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "@mkbhd"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "@mkbhd"
-          }
-        },
-        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "@mkbhd"
@@ -194,6 +194,24 @@
             "value" : "%1$@ ने %2$@ सब्सक्राइबर हासिल कर लिए!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ mencapai %2$@ subscriber!"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ が %2$@ 人の登録者に到達しました！"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ жазылушыға жетті!"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -206,34 +224,16 @@
             "value" : "%1$@ %2$@ சந்தாதாரர்களை எட்டியது!"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ が %2$@ 人の登録者に到達しました！"
+            "value" : "%1$@, %2$@ aboneye ulaştı!"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ 已达到 %2$@ 位订阅者！"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@ жазылушыға жетті!"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ mencapai %2$@ subscriber!"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@, %2$@ aboneye ulaştı!"
           }
         }
       }
@@ -270,6 +270,24 @@
             "value" : "1 घंटा"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 Jam"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1時間"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 сағат"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -282,34 +300,16 @@
             "value" : "1 மணி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1時間"
+            "value" : "1 Saat"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "1小时"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 сағат"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 Jam"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 Saat"
           }
         }
       }
@@ -346,6 +346,24 @@
             "value" : "6 घंटे"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6 Jam"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6時間"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6 сағат"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -358,34 +376,16 @@
             "value" : "6 மணி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "6時間"
+            "value" : "6 Saat"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "6小时"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "6 сағат"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "6 Jam"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "6 Saat"
           }
         }
       }
@@ -422,6 +422,24 @@
             "value" : "12 घंटे"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 Jam"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12時間"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 сағат"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -434,34 +452,16 @@
             "value" : "12 மணி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12時間"
+            "value" : "12 Saat"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "12小时"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "12 сағат"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "12 Jam"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "12 Saat"
           }
         }
       }
@@ -498,6 +498,24 @@
             "value" : "30 मिनट"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 Menit"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30分"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 минут"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -510,34 +528,16 @@
             "value" : "30 நிமிடங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30分"
+            "value" : "30 Dakika"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "30分钟"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 минут"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 Menit"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 Dakika"
           }
         }
       }
@@ -574,6 +574,24 @@
             "value" : "एक्सेंट रंग"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warna aksen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクセントカラー"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Акцент түсі"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -586,10 +604,10 @@
             "value" : "முக்கிய நிறம்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アクセントカラー"
+            "value" : "Vurgu rengi"
           }
         },
         "zh-Hans" : {
@@ -597,23 +615,81 @@
             "state" : "translated",
             "value" : "强调色"
           }
-        },
-        "kk" : {
+        }
+      }
+    },
+    "Add a button to manually refresh the subscriber count" : {
+      "localizations" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Акцент түсі"
+            "value" : "أضف زرًا لتحديث عدد المشتركين يدويًا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Füge eine Schaltfläche hinzu, um die Abonnentenzahl manuell zu aktualisieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agrega un botón para actualizar manualmente el recuento de suscriptores"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajoutez un bouton pour actualiser manuellement le nombre d’abonnés"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "सब्सक्राइबर संख्या को मैन्युअल रूप से रीफ्रेश करने के लिए एक बटन जोड़ें"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Warna aksen"
+            "value" : "Tambahkan tombol untuk me-refresh jumlah subscriber secara manual"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登録者数を手動で更新するためのボタンを追加します"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жазылушылар санын қолмен жаңарту үшін түйме қосыңыз"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicione um botão para atualizar manualmente a contagem de inscritos"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "சந்தாதாரர் எண்ணிக்கையை கைமுறையாக புதுப்பிக்க ஒரு பொத்தானைச் சேர்க்கவும்"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vurgu rengi"
+            "value" : "Abone sayısını manuel olarak yenilemek için bir düğme ekleyin"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加一个按钮以手动刷新订阅者数量"
           }
         }
       }
@@ -650,6 +726,24 @@
             "value" : "एक चैनल जोड़ें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan Saluran"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを追加"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арна қосу"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -662,34 +756,16 @@
             "value" : "ஒரு சேனலைச் சேர்க்கவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを追加"
+            "value" : "Bir Kanal Ekle"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арна қосу"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tambahkan Saluran"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bir Kanal Ekle"
           }
         }
       }
@@ -726,6 +802,24 @@
             "value" : "ऐप में एक चैनल जोड़ें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan saluran di aplikasi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリにチャンネルを追加する"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қолданбаға арна қосыңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -738,34 +832,16 @@
             "value" : "செயலியில் ஒரு சேனலைச் சேர்க்கவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アプリにチャンネルを追加する"
+            "value" : "Uygulamaya bir kanal ekleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "在应用程序中添加频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қолданбаға арна қосыңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tambahkan saluran di aplikasi"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uygulamaya bir kanal ekleyin"
           }
         }
       }
@@ -802,6 +878,24 @@
             "value" : "शुरू करने के लिए एक चैनल जोड़ें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan saluran untuk memulai."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始するにはチャンネルを追加してください。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бастау үшін арна қосыңыз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -814,34 +908,16 @@
             "value" : "தொடங்க ஒரு சேனலைச் சேர்க்கவும்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "開始するにはチャンネルを追加してください。"
+            "value" : "Başlamak için bir kanal ekleyin."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加频道即可开始。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Бастау үшін арна қосыңыз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tambahkan saluran untuk memulai."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Başlamak için bir kanal ekleyin."
           }
         }
       }
@@ -878,6 +954,24 @@
             "value" : "चैनल जोड़ें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan Saluran"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを追加"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арна қосу"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -890,34 +984,16 @@
             "value" : "சேனல் சேர்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを追加"
+            "value" : "Kanal Ekle"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арна қосу"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tambahkan Saluran"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanal Ekle"
           }
         }
       }
@@ -954,6 +1030,24 @@
             "value" : "अपना चैनल जोड़ें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan saluran Anda"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを追加"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арнаңызды қосыңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -966,34 +1060,16 @@
             "value" : "உங்கள் சேனலைச் சேர்க்கவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを追加"
+            "value" : "Kanalınızı ekleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加您的频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арнаңызды қосыңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tambahkan saluran Anda"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanalınızı ekleyin"
           }
         }
       }
@@ -1030,6 +1106,24 @@
             "value" : "अपना पहला चैनल मुफ्त में जोड़ें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan saluran pertama Anda secara gratis"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最初のチャンネルを無料で追加"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бірінші арнаңызды тегін қосыңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1042,34 +1136,16 @@
             "value" : "உங்கள் முதல் சேனலை இலவசமாகச் சேர்க்கவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最初のチャンネルを無料で追加"
+            "value" : "İlk kanalınızı ücretsiz ekleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "免费添加你的第一个频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Бірінші арнаңызды тегін қосыңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tambahkan saluran pertama Anda secara gratis"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İlk kanalınızı ücretsiz ekleyin"
           }
         }
       }
@@ -1106,6 +1182,24 @@
             "value" : "अपना पहला चैनल अभी जोड़ें, फिर जब चाहें विजेट लगा दें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tambahkan saluran pertama Anda sekarang, lalu tempatkan widget saat Anda siap."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今すぐ最初のチャンネルを追加し、準備ができたらウィジェットを配置しましょう。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Алғашқы арнаңызды қазір қосыңыз, дайын болған кезде виджетті орналастырыңыз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1118,34 +1212,16 @@
             "value" : "உங்கள் முதல் சேனலை இப்போது சேர்க்கவும், தயாரானபோது விட்ஜெட்டை இடவும்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "今すぐ最初のチャンネルを追加し、準備ができたらウィジェットを配置しましょう。"
+            "value" : "İlk kanalınızı şimdi ekleyin, ardından hazır olduğunuzda widget'ı yerleştirin."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "现在就添加你的第一个频道，准备好后再摆放小组件。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Алғашқы арнаңызды қазір қосыңыз, дайын болған кезде виджетті орналастырыңыз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tambahkan saluran pertama Anda sekarang, lalu tempatkan widget saat Anda siap."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İlk kanalınızı şimdi ekleyin, ardından hazır olduğunuzda widget'ı yerleştirin."
           }
         }
       }
@@ -1182,6 +1258,24 @@
             "value" : "एमेथिस्ट"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "batu kecubung"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アメジスト"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аметист"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1194,34 +1288,16 @@
             "value" : "அமெதிஸ்ட்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アメジスト"
+            "value" : "Ametist"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "紫水晶"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Аметист"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "batu kecubung"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ametist"
           }
         }
       }
@@ -1258,6 +1334,24 @@
             "value" : "एक नज़र में"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SEKILAS"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ひと目でわかる"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "БІР ҚАРАУДА"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1270,34 +1364,16 @@
             "value" : "ஒரே பார்வையில்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ひと目でわかる"
+            "value" : "BİR BAKIŞTA"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "一目了然"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "БІР ҚАРАУДА"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SEKILAS"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BİR BAKIŞTA"
           }
         }
       }
@@ -1334,6 +1410,24 @@
             "value" : "पृष्ठभूमि"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latar Belakang"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "背景"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фон"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1346,34 +1440,16 @@
             "value" : "பின்னணி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "背景"
+            "value" : "Arkaplan"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "背景"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Фон"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Latar Belakang"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arkaplan"
           }
         }
       }
@@ -1410,6 +1486,24 @@
             "value" : "अर्जुन दुरेजा द्वारा"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "oleh Arjun Dureja"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アルジュン・ドゥレヤ著"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арджун Дурежа"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1422,34 +1516,16 @@
             "value" : "அர்ஜுன் துரேஜா மூலம்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アルジュン・ドゥレヤ著"
+            "value" : "kaydeden Arjun Dureja"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "通过阿琼·杜雷哈"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арджун Дурежа"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "oleh Arjun Dureja"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kaydeden Arjun Dureja"
           }
         }
       }
@@ -1486,6 +1562,24 @@
             "value" : "अपना चैनल नहीं ढूँढ पा रहे हैं?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat menemukan saluran Anda?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルが見つかりませんか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арнаңызды таба алмай жатырсыз ба?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1498,34 +1592,16 @@
             "value" : "உங்கள் சேனலை கண்டுபிடிக்க முடியவில்லையா?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルが見つかりませんか?"
+            "value" : "Kanalınızı bulamıyor musunuz?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "找不到您的频道？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арнаңызды таба алмай жатырсыз ба?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tidak dapat menemukan saluran Anda?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanalınızı bulamıyor musunuz?"
           }
         }
       }
@@ -1562,6 +1638,24 @@
             "value" : "रद्द करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batalkan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Болдырмау"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1574,34 +1668,16 @@
             "value" : "ரத்து செய்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "キャンセル"
+            "value" : "İptal"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Болдырмау"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Batalkan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İptal"
           }
         }
       }
@@ -1638,6 +1714,24 @@
             "value" : "मेल नहीं खुल रहा है"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidak dapat membuka email"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メールを開けません"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поштаны ашу мүмкін емес"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1650,34 +1744,16 @@
             "value" : "மின்னஞ்சலை திறக்க முடியவில்லை"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "メールを開けません"
+            "value" : "Posta açılamıyor"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法打开邮件"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поштаны ашу мүмкін емес"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tidak dapat membuka email"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Posta açılamıyor"
           }
         }
       }
@@ -1714,6 +1790,24 @@
             "value" : "चैनल का नाम या आईडी"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nama atau ID Saluran"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネル名またはID"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арна аты немесе идентификаторы"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1726,34 +1820,16 @@
             "value" : "சேனல் பெயர் அல்லது ஐடி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネル名またはID"
+            "value" : "Kanal Adı veya Kimliği"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "频道名称或ID"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арна аты немесе идентификаторы"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nama atau ID Saluran"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanal Adı veya Kimliği"
           }
         }
       }
@@ -1790,6 +1866,24 @@
             "value" : "चैनल नहीं मिला"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saluran tidak ditemukan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルが見つかりません"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арна табылмады"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1802,34 +1896,16 @@
             "value" : "சேனல் கிடைக்கவில்லை"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルが見つかりません"
+            "value" : "Kanal bulunamadı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "找不到频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арна табылмады"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saluran tidak ditemukan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanal bulunamadı"
           }
         }
       }
@@ -1873,6 +1949,24 @@
             "value" : "चैनल्स"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "saluran"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネル"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "арналар"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1885,34 +1979,16 @@
             "value" : "சேனல்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネル"
+            "value" : "kanallar"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "арналар"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "saluran"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kanallar"
           }
         }
       }
@@ -1949,6 +2025,24 @@
             "value" : "चैनल्स"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saluran"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネル"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арналар"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1961,34 +2055,16 @@
             "value" : "சேனல்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネル"
+            "value" : "Kanallar"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арналар"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saluran"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanallar"
           }
         }
       }
@@ -2025,6 +2101,24 @@
             "value" : "चुनें कि सब्सक्राइबर काउंट कितनी बार अपडेट होना चाहिए"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih seberapa sering jumlah pelanggan harus diperbarui"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登録者数を更新する頻度を選択します"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жазылушылар саны қаншалықты жиі жаңартылатынын таңдаңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2037,34 +2131,16 @@
             "value" : "சந்தாதாரர் எண்ணிக்கை எவ்வளவு அடிக்கடி புதுப்பிக்கப்பட வேண்டும் என்பதை தெரிவு செய்க"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "登録者数を更新する頻度を選択します"
+            "value" : "Abone sayısının ne sıklıkta güncelleneceğini seçin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择订阅者计数更新的频率"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жазылушылар саны қаншалықты жиі жаңартылатынын таңдаңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pilih seberapa sering jumlah pelanggan harus diperbarui"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abone sayısının ne sıklıkta güncelleneceğini seçin"
           }
         }
       }
@@ -2101,6 +2177,24 @@
             "value" : "साइट्रस रात"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Malam Jeruk"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シトラスナイト"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цитрус түні"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2113,34 +2207,16 @@
             "value" : "சிட்ரஸ் இரவு"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "シトラスナイト"
+            "value" : "Narenciye Gecesi"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "柑橘之夜"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Цитрус түні"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Malam Jeruk"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Narenciye Gecesi"
           }
         }
       }
@@ -2177,6 +2253,24 @@
             "value" : "रंग"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warna"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "色"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Түстер"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2189,34 +2283,16 @@
             "value" : "நிறங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "色"
+            "value" : "Renkler"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "颜色"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Түстер"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warna"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renkler"
           }
         }
       }
@@ -2253,6 +2329,24 @@
             "value" : "संपर्क करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontak"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お問い合わせ"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Байланыс"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2265,34 +2359,16 @@
             "value" : "தொடர்பு"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "お問い合わせ"
+            "value" : "İletişim"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "联系方式"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Байланыс"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontak"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İletişim"
           }
         }
       }
@@ -2329,6 +2405,24 @@
             "value" : "जारी रखें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lanjutkan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "続ける"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жалғастыру"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2341,34 +2435,16 @@
             "value" : "தொடரவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "続ける"
+            "value" : "Devam et"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "继续"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жалғастыру"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lanjutkan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Devam et"
           }
         }
       }
@@ -2405,6 +2481,24 @@
             "value" : "कोरल"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Karang"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サンゴ"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Маржан"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2417,34 +2511,16 @@
             "value" : "கோரல்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "サンゴ"
+            "value" : "Mercan"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "珊瑚"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Маржан"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Karang"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mercan"
           }
         }
       }
@@ -2481,6 +2557,24 @@
             "value" : "डीपसी"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "laut dalam"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深海"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Терең теңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2493,34 +2587,16 @@
             "value" : "ஆழ்கடல்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "深海"
+            "value" : "Derin deniz"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "深海"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Терең теңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "laut dalam"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Derin deniz"
           }
         }
       }
@@ -2557,6 +2633,24 @@
             "value" : "हटाएँ"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hapus"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жою"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2569,34 +2663,16 @@
             "value" : "நீக்கு"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "削除"
+            "value" : "Sil"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жою"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hapus"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sil"
           }
         }
       }
@@ -2633,6 +2709,24 @@
             "value" : "बड़ी संख्याओं को एक संक्षिप्त, सरलीकृत प्रारूप में प्रदर्शित करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menampilkan angka besar dalam format yang ringkas dan disederhanakan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大きな数値をコンパクトで簡略化した形式で表示する"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Үлкен сандарды ықшам, жеңілдетілген форматта көрсетіңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2645,34 +2739,16 @@
             "value" : "பெரிய எண்களை ஒரு சுருக்கமான, எளிமையான வடிவத்தில் காட்டவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "大きな数値をコンパクトで簡略化した形式で表示する"
+            "value" : "Büyük sayıları kompakt, basitleştirilmiş bir biçimde görüntüleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "以紧凑、简化的格式显示大量数字"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Үлкен сандарды ықшам, жеңілдетілген форматта көрсетіңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menampilkan angka besar dalam format yang ringkas dan disederhanakan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Büyük sayıları kompakt, basitleştirilmiş bir biçimde görüntüleyin"
           }
         }
       }
@@ -2709,6 +2785,24 @@
             "value" : "उस समय को दिखाएं जब ग्राहक संख्या आखिरी बार अपडेट की गई थी"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menampilkan waktu terakhir kali jumlah pelanggan diperbarui"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登録者数が最後に更新された時間を表示します"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жазылушылар саны соңғы рет жаңартылған уақытты көрсетіңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2721,34 +2815,16 @@
             "value" : "சந்தாதாரர் எண்ணிக்கை கடைசியாக புதுப்பிக்கப்பட்ட நேரத்தை காட்டவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "登録者数が最後に更新された時間を表示します"
+            "value" : "Abone sayısının en son güncellendiği zamanı görüntüleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示订阅者计数上次更新的时间"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жазылушылар саны соңғы рет жаңартылған уақытты көрсетіңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menampilkan waktu terakhir kali jumlah pelanggan diperbarui"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abone sayısının en son güncellendiği zamanı görüntüleyin"
           }
         }
       }
@@ -2785,6 +2861,24 @@
             "value" : "हो गया"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selesai"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дайын"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2797,34 +2891,16 @@
             "value" : "முடிந்தது"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "完了"
+            "value" : "Bitti"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "完成"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дайын"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selesai"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitti"
           }
         }
       }
@@ -2861,6 +2937,24 @@
             "value" : "एमराल्ड"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zamrud"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エメラルド"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изумруд"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2873,34 +2967,16 @@
             "value" : "மரகதம்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "エメラルド"
+            "value" : "Zümrüt"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "祖母绿"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изумруд"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zamrud"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zümrüt"
           }
         }
       }
@@ -2937,6 +3013,24 @@
             "value" : "माइलस्टोन अलर्ट पाने के लिए सेटिंग्स में नोटिफिकेशन सक्षम करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktifkan notifikasi di Pengaturan untuk menerima peringatan pencapaian"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マイルストーンアラートを受信するには、設定で通知を有効にしてください"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Маңызды кезең туралы ескертулерді алу үшін «Параметрлер» бөлімінде хабарландыруларды қосыңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2949,34 +3043,16 @@
             "value" : "மைல்கல் அறிவிப்புகளைப் பெற அமைப்புகளில் அறிவிப்புகளை இயக்கவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "マイルストーンアラートを受信するには、設定で通知を有効にしてください"
+            "value" : "Aşama uyarıları almak için Ayarlar'da bildirimleri etkinleştirin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "在“设置”中启用通知以接收里程碑警报"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Маңызды кезең туралы ескертулерді алу үшін «Параметрлер» бөлімінде хабарландыруларды қосыңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktifkan notifikasi di Pengaturan untuk menerima peringatan pencapaian"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aşama uyarıları almak için Ayarlar'da bildirimleri etkinleştirin"
           }
         }
       }
@@ -3013,6 +3089,24 @@
             "value" : "यूट्यूब चैनल का नाम या आईडी दर्ज करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masukkan nama atau ID saluran YouTube"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube チャンネル名または ID を入力してください"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube арнасының атын немесе идентификаторын енгізіңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3025,34 +3119,16 @@
             "value" : "யூடியூப் சேனல் பெயர் அல்லது ஐடியை உள்ளிடவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "YouTube チャンネル名または ID を入力してください"
+            "value" : "Bir YouTube kanal adı veya kimliği girin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入 YouTube 频道名称或 ID"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YouTube арнасының атын немесе идентификаторын енгізіңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Masukkan nama atau ID saluran YouTube"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bir YouTube kanal adı veya kimliği girin"
           }
         }
       }
@@ -3089,6 +3165,24 @@
             "value" : "सामान्य प्रश्न"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pertanyaan Umum"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "よくある質問"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жиі қойылатын сұрақтар"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3101,34 +3195,16 @@
             "value" : "அடிக்கடி கேட்கப்படும் கேள்விகள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "よくある質問"
+            "value" : "SSS"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "常见问题解答"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жиі қойылатын сұрақтар"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pertanyaan Umum"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SSS"
           }
         }
       }
@@ -3165,6 +3241,24 @@
             "value" : "कोई चैनल खोजें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TEMUKAN SALURAN"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを探す"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "АРНАНЫ ТАБУ"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3177,34 +3271,16 @@
             "value" : "ஒரு சேனலைத் தேடுங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを探す"
+            "value" : "KANAL BUL"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "查找频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "АРНАНЫ ТАБУ"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "TEMUKAN SALURAN"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "KANAL BUL"
           }
         }
       }
@@ -3241,6 +3317,24 @@
             "value" : "मेरी आईडी खोजें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temukan ID Saya"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IDを探す"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Менің жеке куәлігімді табыңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3253,34 +3347,16 @@
             "value" : "எனது ஐடியைக் கண்டுபிடி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "IDを探す"
+            "value" : "Kimliğimi Bul"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "查找我的身份证"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Менің жеке куәлігімді табыңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temukan ID Saya"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kimliğimi Bul"
           }
         }
       }
@@ -3317,6 +3393,24 @@
             "value" : "सबसे पहले, अपनी लॉक स्क्रीन पर टैप करके रखें और 'कस्टमाइज़' पर टैप करें। फिर आप विजेट जोड़ सकते हैं और उसे टैप करके चैनल चुन सकते हैं।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pertama, ketuk dan tahan Layar Terkunci Anda dan ketuk 'Sesuaikan'. Kemudian Anda dapat menambahkan widget dan mengetuknya untuk memilih saluran."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まず、ロック画面を長押しして「カスタマイズ」をタップします。次に、ウィジェットを追加し、タップしてチャンネルを選択します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Алдымен құлыптау экранын түртіп, ұстап тұрыңыз және «Реттеу» түймесін түртіңіз. Содан кейін виджетті қосып, арнаны таңдау үшін оны түртуге болады."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3329,34 +3423,16 @@
             "value" : "முதலில், உங்கள் பூட்டு திரையில் தட்டி அழுத்தி 'விருப்பமைக்கவும்' என்று தட்டவும். பின்னர் நீங்கள் விஜெட்டைச் சேர்க்கலாம் மற்றும் சேனலைத் தெரிவு செய்ய அதை தட்டலாம்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "まず、ロック画面を長押しして「カスタマイズ」をタップします。次に、ウィジェットを追加し、タップしてチャンネルを選択します。"
+            "value" : "Öncelikle Kilit Ekranınıza dokunup basılı tutun ve 'Özelleştir'e dokunun. Daha sonra widget'ı ekleyebilir ve kanalı seçmek için ona dokunabilirsiniz."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "首先，点击并按住锁定屏幕，然后点击“自定义”。然后您可以添加小组件并点击它来选择频道。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Алдымен құлыптау экранын түртіп, ұстап тұрыңыз және «Реттеу» түймесін түртіңіз. Содан кейін виджетті қосып, арнаны таңдау үшін оны түртуге болады."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pertama, ketuk dan tahan Layar Terkunci Anda dan ketuk 'Sesuaikan'. Kemudian Anda dapat menambahkan widget dan mengetuknya untuk memilih saluran."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öncelikle Kilit Ekranınıza dokunup basılı tutun ve 'Özelleştir'e dokunun. Daha sonra widget'ı ekleyebilir ve kanalı seçmek için ona dokunabilirsiniz."
           }
         }
       }
@@ -3393,6 +3469,24 @@
             "value" : "शुरू करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memulai"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "始めましょう"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жұмысты бастау"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3405,34 +3499,16 @@
             "value" : "தொடங்குங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "始めましょう"
+            "value" : "Başlarken"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "开始使用"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жұмысты бастау"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memulai"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Başlarken"
           }
         }
       }
@@ -3469,6 +3545,24 @@
             "value" : "इस विजेट का उपयोग करने के लिए SubWidget Pro प्राप्त करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dapatkan SubWidget Pro untuk menggunakan widget ini"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このウィジェットを使うには SubWidget Pro が必要です"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бұл виджетті пайдалану үшін SubWidget Pro қажет"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3481,34 +3575,16 @@
             "value" : "இந்த விட்ஜெட்டை பயன்படுத்த SubWidget Pro ஐப் பெறுங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このウィジェットを使うには SubWidget Pro が必要です"
+            "value" : "Bu widget'ı kullanmak için SubWidget Pro gerekir"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用此小组件需要 SubWidget Pro"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Бұл виджетті пайдалану үшін SubWidget Pro қажет"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dapatkan SubWidget Pro untuk menggunakan widget ini"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu widget'ı kullanmak için SubWidget Pro gerekir"
           }
         }
       }
@@ -3545,6 +3621,24 @@
             "value" : "हार्वेस्ट"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Panen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "収穫"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Егін жинау"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3557,34 +3651,16 @@
             "value" : "அறுவடை"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "収穫"
+            "value" : "Hasat"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "收获"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Егін жинау"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Panen"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hasat"
           }
         }
       }
@@ -3633,6 +3709,24 @@
             "value" : "दबाकर रखें, फिर 'एडिट विजेट' पर टैप करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tahan dan ketuk 'Edit Widget'"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長押しして「ウィジェットを編集」をタップします"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"Виджетті өңдеу\" түймесін басып тұрыңыз және түртіңіз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3645,34 +3739,16 @@
             "value" : "அழுத்திப் பிடித்து, பின்னர் 'விட்ஜெட்டைத் திருத்து' என்பதைத் தட்டவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "長押しして「ウィジェットを編集」をタップします"
+            "value" : "Basılı tutun ve 'Widget'ı Düzenle'ye dokunun"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "按住并点击“编辑小组件”"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"Виджетті өңдеу\" түймесін басып тұрыңыз және түртіңіз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tahan dan ketuk 'Edit Widget'"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basılı tutun ve 'Widget'ı Düzenle'ye dokunun"
           }
         }
       }
@@ -3709,6 +3785,24 @@
             "value" : "होम"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rumah"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Үй"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3721,34 +3815,16 @@
             "value" : "முகப்பு"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ホーム"
+            "value" : "Ana sayfa"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "首页"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Үй"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rumah"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ana sayfa"
           }
         }
       }
@@ -3785,6 +3861,24 @@
             "value" : "मैं अपनी होमस्क्रीन पर विजेट कैसे जोड़ूं?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagaimana cara menambahkan widget ke layar beranda saya?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム画面にウィジェットを追加するにはどうすればよいですか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджетті негізгі экранға қалай қосуға болады?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3797,34 +3891,16 @@
             "value" : "என் முகப்புத் திரையில் விஜெட்டை எப்படி சேர்க்கலாம்?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ホーム画面にウィジェットを追加するにはどうすればよいですか?"
+            "value" : "Widget'ı ana ekranıma nasıl eklerim?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "如何将小组件添加到我的主屏幕？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджетті негізгі экранға қалай қосуға болады?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bagaimana cara menambahkan widget ke layar beranda saya?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget'ı ana ekranıma nasıl eklerim?"
           }
         }
       }
@@ -3861,6 +3937,24 @@
             "value" : "मैं अपनी लॉक स्क्रीन पर विजेट कैसे जोड़ूं?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagaimana cara menambahkan widget ke Layar Terkunci saya?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロック画面にウィジェットを追加するにはどうすればよいですか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Құлыптау экранына виджетті қалай қосуға болады?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3873,34 +3967,16 @@
             "value" : "என் பூட்டு திரையில் விஜெட்டை எப்படி சேர்க்கலாம்?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ロック画面にウィジェットを追加するにはどうすればよいですか?"
+            "value" : "Kilit Ekranıma nasıl widget eklerim?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "如何将小组件添加到我的锁定屏幕？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Құлыптау экранына виджетті қалай қосуға болады?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bagaimana cara menambahkan widget ke Layar Terkunci saya?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kilit Ekranıma nasıl widget eklerim?"
           }
         }
       }
@@ -3937,6 +4013,24 @@
             "value" : "मैं किसी चैनल को कैसे हटाऊँ?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagaimana cara menghapus saluran?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを削除するにはどうすればよいですか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арнаны қалай жоюға болады?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3949,34 +4043,16 @@
             "value" : "ஒரு சேனலை எப்படி நீக்குவது?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを削除するにはどうすればよいですか?"
+            "value" : "Bir kanalı nasıl silerim?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "如何删除频道？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арнаны қалай жоюға болады?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bagaimana cara menghapus saluran?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bir kanalı nasıl silerim?"
           }
         }
       }
@@ -4013,6 +4089,24 @@
             "value" : "मैं कितने चैनल जोड़ सकता हूँ?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Berapa banyak saluran yang dapat saya tambahkan?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルは何個まで追加できますか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қанша арна қосуға болады?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4025,34 +4119,16 @@
             "value" : "நான் எத்தனை சேனல்களை சேர்க்கலாம்?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルは何個まで追加できますか?"
+            "value" : "Kaç kanal ekleyebilirim?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "我可以添加多少个频道？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қанша арна қосуға болады?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berapa banyak saluran yang dapat saya tambahkan?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaç kanal ekleyebilirim?"
           }
         }
       }
@@ -4089,6 +4165,24 @@
             "value" : "सब्सक्राइबर काउंट कितनी बार अपडेट होता है?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seberapa sering pembaruan jumlah pelanggan?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネル登録者数はどのくらいの頻度で更新されますか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жазылушылар саны қаншалықты жиі жаңартылады?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4101,34 +4195,16 @@
             "value" : "சந்தாதாரர் எண்ணிக்கை எவ்வளவு அடிக்கடி புதுப்பிக்கப்படுகிறது?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネル登録者数はどのくらいの頻度で更新されますか?"
+            "value" : "Abone sayısı ne sıklıkla güncellenir?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "订阅者数量多久更新一次？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жазылушылар саны қаншалықты жиі жаңартылады?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seberapa sering pembaruan jumlah pelanggan?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abone sayısı ne sıklıkla güncellenir?"
           }
         }
       }
@@ -4165,6 +4241,24 @@
             "value" : "मुझे अपना चैनल नहीं मिल रहा है।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saya tidak dapat menemukan saluran saya."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自分のチャンネルが見つかりません。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Мен өз арнамды таба алмаймын."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4177,34 +4271,16 @@
             "value" : "எனது சேனலை கண்டுபிடிக்க முடியவில்லை."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自分のチャンネルが見つかりません。"
+            "value" : "Kanalımı bulamıyorum."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "我找不到我的频道。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Мен өз арнамды таба алмаймын."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saya tidak dapat menemukan saluran saya."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanalımı bulamıyorum."
           }
         }
       }
@@ -4241,6 +4317,24 @@
             "value" : "मेरे पास एक फीचर आइडिया है जिसे मैं अनुरोध करना चाहता हूँ।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saya punya ide fitur yang ingin saya minta."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストしたい機能のアイデアがあります。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Менде сұрағым келетін мүмкіндік идеясы бар."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4253,34 +4347,16 @@
             "value" : "நான் கேட்க விரும்பும் ஒரு அம்ச யோசனை உள்ளது."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リクエストしたい機能のアイデアがあります。"
+            "value" : "Talep etmek istediğim bir özellik fikrim var."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "我有一个想要请求的功能想法。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Менде сұрағым келетін мүмкіндік идеясы бар."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saya punya ide fitur yang ingin saya minta."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Talep etmek istediğim bir özellik fikrim var."
           }
         }
       }
@@ -4317,6 +4393,24 @@
             "value" : "माइलस्टोन सूचनाएँ"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifikasi Pencapaian"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マイルストーン通知"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Белес хабарландырулары"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4329,34 +4423,16 @@
             "value" : "மைல்கல் அறிவிப்புகள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "マイルストーン通知"
+            "value" : "Dönüm Noktası Bildirimleri"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "里程碑通知"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Белес хабарландырулары"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifikasi Pencapaian"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dönüm Noktası Bildirimleri"
           }
         }
       }
@@ -4399,6 +4475,24 @@
             "value" : "माइलस्टोन हासिल हुआ!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tonggak Pencapaian Tercapai!"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マイルストーンに到達しました!"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Белгіленген межеге жетті!"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4411,34 +4505,16 @@
             "value" : "மைல்கல் எட்டப்பட்டது!"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "マイルストーンに到達しました!"
+            "value" : "Kilometre Taşına Ulaşıldı!"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "里程碑已达！"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Белгіленген межеге жетті!"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tonggak Pencapaian Tercapai!"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kilometre Taşına Ulaşıldı!"
           }
         }
       }
@@ -4475,6 +4551,24 @@
             "value" : "मिंटेड"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dicetak"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鋳造された"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "соғылған"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4487,34 +4581,16 @@
             "value" : "மின்டெட்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "鋳造された"
+            "value" : "Darphane"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "铸造"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "соғылған"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "dicetak"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Darphane"
           }
         }
       }
@@ -4551,6 +4627,24 @@
             "value" : "मेरा सवाल यहां सूचीबद्ध नहीं है।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pertanyaan saya tidak tercantum di sini."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私の質問はここには記載されていません。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Менің сұрағым мұнда тізімде жоқ."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4563,34 +4657,16 @@
             "value" : "என் கேள்வி இங்கே பட்டியலிடப்படவில்லை."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "私の質問はここには記載されていません。"
+            "value" : "Sorum burada listelenmiyor."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "我的问题没有在这里列出。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Менің сұрағым мұнда тізімде жоқ."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pertanyaan saya tidak tercantum di sini."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sorum burada listelenmiyor."
           }
         }
       }
@@ -4627,6 +4703,24 @@
             "value" : "नॉटिकल"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bahari"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "航海用"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Теңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4639,34 +4733,16 @@
             "value" : "கடல்வாழ்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "航海用"
+            "value" : "denizcilik"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "航海"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Теңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bahari"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "denizcilik"
           }
         }
       }
@@ -4703,6 +4779,24 @@
             "value" : "नेटवर्क त्रुटि। कृपया बाद में पुनः प्रयास करें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kesalahan jaringan. Silakan coba lagi nanti."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネットワークエラー。後でもう一度試してください。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Желі қатесі. Тағы жасауды сәл кейінірек көріңізді өтінеміз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4715,34 +4809,16 @@
             "value" : "நெட்வொர்க் பிழை. தயவுசெய்து பின்னர் முயற்சிக்கவும்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ネットワークエラー。後でもう一度試してください。"
+            "value" : "Ağ hatası. Lütfen daha sonra tekrar deneyin."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "网络错误。请稍后重试。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Желі қатесі. Тағы жасауды сәл кейінірек көріңізді өтінеміз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kesalahan jaringan. Silakan coba lagi nanti."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ağ hatası. Lütfen daha sonra tekrar deneyin."
           }
         }
       }
@@ -4779,6 +4855,24 @@
             "value" : "नेटवर्क त्रुटि। कृपया पुनः प्रयास करें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kesalahan jaringan. Silakan coba lagi."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネットワークエラー。もう一度試してください。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Желі қатесі. Қайталап көріңіз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4791,34 +4885,16 @@
             "value" : "நெட்வொர்க் பிழை. தயவுசெய்து மீண்டும் முயற்சிக்கவும்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ネットワークエラー。もう一度試してください。"
+            "value" : "Ağ hatası. Lütfen tekrar deneyin."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "网络错误。请再试一次。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Желі қатесі. Қайталап көріңіз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kesalahan jaringan. Silakan coba lagi."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ağ hatası. Lütfen tekrar deneyin."
           }
         }
       }
@@ -4855,6 +4931,24 @@
             "value" : "अभी तक कोई चैनल नहीं जोड़ा गया है"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Belum ada saluran yang ditambahkan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まだチャンネルは追加されていません"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арналар әлі қосылмаған"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4867,34 +4961,16 @@
             "value" : "இன்னும் எந்த சேனல்களும் சேர்க்கப்படவில்லை"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "まだチャンネルは追加されていません"
+            "value" : "Henüz kanal eklenmedi"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "尚未添加频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арналар әлі қосылмаған"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Belum ada saluran yang ditambahkan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Henüz kanal eklenmedi"
           }
         }
       }
@@ -4931,6 +5007,24 @@
             "value" : "सूचनाएँ बंद हैं"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifikasi Dinonaktifkan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知が無効になっています"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Хабарландырулар өшірілген"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4943,34 +5037,16 @@
             "value" : "அறிவிப்புகள் முடக்கப்பட்டுள்ளன"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "通知が無効になっています"
+            "value" : "Bildirimler Devre Dışı Bırakıldı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "通知已禁用"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хабарландырулар өшірілген"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifikasi Dinonaktifkan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bildirimler Devre Dışı Bırakıldı"
           }
         }
       }
@@ -5007,6 +5083,24 @@
             "value" : "संख्या"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nomor"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "番号"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сан"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5019,34 +5113,16 @@
             "value" : "எண்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "番号"
+            "value" : "Sayı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "数量"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сан"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nomor"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sayı"
           }
         }
       }
@@ -5083,6 +5159,24 @@
             "value" : "ठीक है"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oke"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жарайды"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5095,34 +5189,16 @@
             "value" : "சரி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
+            "value" : "tamam"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "好的"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жарайды"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oke"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tamam"
           }
         }
       }
@@ -5159,6 +5235,24 @@
             "value" : "ओनिक्स"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "oniks"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オニキス"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оникс"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5171,34 +5265,16 @@
             "value" : "ஆனிக்ஸ்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "オニキス"
+            "value" : "Oniks"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "玛瑙"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Оникс"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "oniks"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oniks"
           }
         }
       }
@@ -5235,6 +5311,24 @@
             "value" : "सेटिंग्स खोलें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka Pengaturan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定を開く"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Параметрлерді ашыңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5247,34 +5341,16 @@
             "value" : "அமைப்புகளைத் திற"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "設定を開く"
+            "value" : "Ayarları Aç"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开设置"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Параметрлерді ашыңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buka Pengaturan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayarları Aç"
           }
         }
       }
@@ -5311,6 +5387,24 @@
             "value" : "ऑर्किड"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anggrek"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蘭"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Орхидея"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5323,34 +5417,16 @@
             "value" : "ஆர்க்கிட்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "蘭"
+            "value" : "Orkide"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "兰花"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Орхидея"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anggrek"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Orkide"
           }
         }
       }
@@ -5387,6 +5463,24 @@
             "value" : "पैलेट्स"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Palet"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パレット"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Палитралар"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5399,34 +5493,16 @@
             "value" : "பேலட்டுகள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "パレット"
+            "value" : "Paletler"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "调色板"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Палитралар"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Palet"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paletler"
           }
         }
       }
@@ -5463,6 +5539,24 @@
             "value" : "पैट्रियट"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Patriot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パトリオット"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Патриот"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5475,34 +5569,16 @@
             "value" : "தேசபக்தன்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "パトリオット"
+            "value" : "Vatansever"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "爱国者"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Патриот"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Patriot"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vatansever"
           }
         }
       }
@@ -5539,6 +5615,24 @@
             "value" : "विजेट लगाएं"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempatkan widget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットを配置"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджетті орналастыру"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5551,34 +5645,16 @@
             "value" : "விட்ஜெட்டை இடவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ウィジェットを配置"
+            "value" : "Widget'ı Yerleştir"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "摆放小组件"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджетті орналастыру"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tempatkan widget"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget'ı Yerleştir"
           }
         }
       }
@@ -5615,6 +5691,24 @@
             "value" : "सेटिंग्स स्क्रीन से मुझसे संपर्क करें, मैं आपके किसी भी सवाल का जवाब दूंगा। मैं आमतौर पर कुछ घंटों के भीतर जवाब देता हूं!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Silakan hubungi saya dari layar pengaturan dan saya akan menjawab pertanyaan apa pun yang Anda miliki. Saya biasanya merespons dalam beberapa jam!."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定画面よりご連絡いただければ質問にお答えします。通常、数時間以内に返信します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Параметрлер экранынан маған хабарласыңыз, мен кез келген сұрағыңызға жауап беремін. Мен әдетте бірнеше сағат ішінде жауап беремін!."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5627,34 +5721,16 @@
             "value" : "அமைப்புகள் திரையிலிருந்து என்னை தொடர்பு கொள்ளுங்கள்; உங்களிடம் உள்ள எந்தக் கேள்விக்கும் நான் பதில் அளிப்பேன். பொதுவாக சில மணி நேரங்களுக்குள் பதிலளிக்கிறேன்!"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "設定画面よりご連絡いただければ質問にお答えします。通常、数時間以内に返信します。"
+            "value" : "Lütfen ayarlar ekranından benimle iletişime geçin, sorularınızı yanıtlayacağım. Genellikle birkaç saat içinde yanıt veririm!"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "请从设置屏幕与我联系，我将回答您的任何问题。我通常会在几个小时内回复！"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Параметрлер экранынан маған хабарласыңыз, мен кез келген сұрағыңызға жауап беремін. Мен әдетте бірнеше сағат ішінде жауап беремін!."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Silakan hubungi saya dari layar pengaturan dan saya akan menjawab pertanyaan apa pun yang Anda miliki. Saya biasanya merespons dalam beberapa jam!."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lütfen ayarlar ekranından benimle iletişime geçin, sorularınızı yanıtlayacağım. Genellikle birkaç saat içinde yanıt veririm!"
           }
         }
       }
@@ -5691,6 +5767,24 @@
             "value" : "कृपया जारी रखने के लिए एक मेल ऐप स्थापित करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Silakan instal aplikasi email untuk melanjutkan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "続行するにはメール アプリをインストールしてください"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жалғастыру үшін пошта қолданбасын орнатыңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5703,34 +5797,16 @@
             "value" : "தொடர ஒரு மின்னஞ்சல் செயலியை நிறுவவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "続行するにはメール アプリをインストールしてください"
+            "value" : "Devam etmek için lütfen bir posta uygulaması yükleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "请安装邮件应用程序以继续"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жалғастыру үшін пошта қолданбасын орнатыңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Silakan instal aplikasi email untuk melanjutkan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Devam etmek için lütfen bir posta uygulaması yükleyin"
           }
         }
       }
@@ -5767,6 +5843,24 @@
             "value" : "कृपया अपनी होमस्क्रीन से विजेट को हटा दें और उसे फिर से जोड़ें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Harap hapus widget dari layar beranda Anda dan tambahkan kembali."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム画面からウィジェットを削除し、再度追加してください。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджетті негізгі экраннан алып тастап, қайта қосыңыз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5779,34 +5873,16 @@
             "value" : "தயவுசெய்து உங்கள் முகப்புத் திரையிலிருந்து விஜெட்டை நீக்கி மீண்டும் சேர்க்கவும்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ホーム画面からウィジェットを削除し、再度追加してください。"
+            "value" : "Lütfen widget'ı ana ekranınızdan kaldırın ve tekrar ekleyin."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "请从主屏幕中删除该小组件并将其添加回来。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджетті негізгі экраннан алып тастап, қайта қосыңыз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Harap hapus widget dari layar beranda Anda dan tambahkan kembali."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lütfen widget'ı ana ekranınızdan kaldırın ve tekrar ekleyin."
           }
         }
       }
@@ -5843,6 +5919,24 @@
             "value" : "पूर्वावलोकन"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pratinjau"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビュー"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Алдын ала қарау"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5855,34 +5949,16 @@
             "value" : "முன்னோட்டம்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "プレビュー"
+            "value" : "Önizleme"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "预览"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Алдын ала қарау"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pratinjau"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Önizleme"
           }
         }
       }
@@ -5919,6 +5995,24 @@
             "value" : "गोपनीयता नीति"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kebijakan Privasi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライバシーポリシー"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Құпиялық саясаты"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5931,34 +6025,16 @@
             "value" : "தனியுரிமை கொள்கை"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "プライバシーポリシー"
+            "value" : "Gizlilik Politikası"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐私政策"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Құпиялық саясаты"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kebijakan Privasi"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gizlilik Politikası"
           }
         }
       }
@@ -5995,6 +6071,24 @@
             "value" : "Pro"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6007,31 +6101,13 @@
             "value" : "Pro"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pro"
           }
         },
         "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pro"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pro"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pro"
-          }
-        },
-        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pro"
@@ -6071,6 +6147,24 @@
             "value" : "PRO"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PRO"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PRO"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PRO"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6083,31 +6177,13 @@
             "value" : "PRO"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "PRO"
           }
         },
         "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PRO"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PRO"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PRO"
-          }
-        },
-        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "PRO"
@@ -6147,6 +6223,24 @@
             "value" : "मूल्यांकन करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nilai"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "料金"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бағалау"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6159,10 +6253,10 @@
             "value" : "விகிதம்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "料金"
+            "value" : "Oran"
           }
         },
         "zh-Hans" : {
@@ -6170,23 +6264,233 @@
             "state" : "translated",
             "value" : "率"
           }
-        },
-        "kk" : {
+        }
+      }
+    },
+    "Refresh Button" : {
+      "localizations" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Бағалау"
+            "value" : "زر التحديث"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualisieren-Button"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Botón de actualizar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bouton d’actualisation"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "रिफ्रेश बटन"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nilai"
+            "value" : "Tombol Refresh"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新ボタン"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жаңарту түймесі"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Botão de atualizar"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "புதுப்பிப்பு பொத்தான்"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oran"
+            "value" : "Yenile Düğmesi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新按钮"
+          }
+        }
+      }
+    },
+    "Refresh Widget" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحديث الأداة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget aktualisieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar widget"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualiser le widget"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विजेट रीफ्रेश करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Segarkan Widget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットを更新"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджетті жаңарту"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atualizar widget"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "விட்ஜெட்டை புதுப்பிக்கவும்"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget'i Yenile"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新小组件"
+          }
+        }
+      }
+    },
+    "Refreshes the widget timeline." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يُحدّث الجدول الزمني للأداة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualisiert die Widget-Zeitleiste."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualiza la línea de tiempo del widget."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualise la chronologie du widget."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विजेट की टाइमलाइन को रीफ्रेश करता है।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menyegarkan linimasa widget."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットのタイムラインを更新します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджеттің уақыт шкаласын жаңартады."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atualiza a linha do tempo do widget."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "விட்ஜெட்டின் காலவரிசையை புதுப்பிக்கும்."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget zaman akışını yeniler."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新小组件时间线。"
           }
         }
       }
@@ -6223,6 +6527,24 @@
             "value" : "रीसेट"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setel ulang"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リセット"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қалпына келтіру"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6235,34 +6557,16 @@
             "value" : "மீட்டமை"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リセット"
+            "value" : "Sıfırla"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қалпына келтіру"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setel ulang"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sıfırla"
           }
         }
       }
@@ -6299,6 +6603,24 @@
             "value" : "विजेट के रंग डिफ़ॉल्ट पर वापस कर देता है - लाइट मोड में सफेद और डार्क मोड में काला।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengembalikan warna widget ke default - Putih dalam mode terang dan hitam dalam mode gelap."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットの色をデフォルト (ライト モードでは白、ダーク モードでは黒) に戻します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджет түстерін әдепкі мәндерге қалпына келтіреді - жарық режимінде ақ және қараңғы режимде қара."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6311,34 +6633,16 @@
             "value" : "விட்ஜெட்டின் நிறங்களை இயல்புநிலைக்கு மீட்டமைக்கும் - ஒளி முறையில் வெள்ளை, இருள் முறையில் கருப்பு."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ウィジェットの色をデフォルト (ライト モードでは白、ダーク モードでは黒) に戻します。"
+            "value" : "Widget'ın renklerini varsayılan ayarlara geri yükler - Açık modda beyaz ve karanlık modda siyah."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "将小组件的颜色恢复为默认值 - 浅色模式下为白色，深色模式下为黑色。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджет түстерін әдепкі мәндерге қалпына келтіреді - жарық режимінде ақ және қараңғы режимде қара."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mengembalikan warna widget ke default - Putih dalam mode terang dan hitam dalam mode gelap."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget'ın renklerini varsayılan ayarlara geri yükler - Açık modda beyaz ve karanlık modda siyah."
           }
         }
       }
@@ -6375,6 +6679,24 @@
             "value" : "रोज़वुड"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kayu mawar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローズウッド"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Раушан ағашы"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6387,34 +6709,16 @@
             "value" : "ரோஸ்வுட்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ローズウッド"
+            "value" : "Gülağacı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "玫瑰木"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Раушан ағашы"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "kayu mawar"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gülağacı"
           }
         }
       }
@@ -6451,6 +6755,24 @@
             "value" : "रूबी"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "rubi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ルビー"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruby"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6463,34 +6785,16 @@
             "value" : "ரூபி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ルビー"
+            "value" : "Yakut"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "红宝石"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruby"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "rubi"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yakut"
           }
         }
       }
@@ -6527,6 +6831,24 @@
             "value" : "रेत-पत्थर"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batupasir"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "砂岩"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Құмтас"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6539,34 +6861,16 @@
             "value" : "மணற்கல்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "砂岩"
+            "value" : "Kumtaşı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "砂岩"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Құмтас"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Batupasir"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kumtaşı"
           }
         }
       }
@@ -6603,6 +6907,24 @@
             "value" : "एक चैनल खोजें। विजेट जोड़ें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cari saluran. Tambahkan widget."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを検索。ウィジェットを追加。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арнаны іздеңіз. Виджетті қосыңыз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6615,34 +6937,16 @@
             "value" : "ஒரு சேனலைத் தேடுங்கள். விட்ஜெட்டைச் சேர்க்கவும்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを検索。ウィジェットを追加。"
+            "value" : "Bir kanal arayın. Widget'ı ekleyin."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索频道。添加小组件。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арнаны іздеңіз. Виджетті қосыңыз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cari saluran. Tambahkan widget."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bir kanal arayın. Widget'ı ekleyin."
           }
         }
       }
@@ -6679,6 +6983,24 @@
             "value" : "नाम, @हैंडल या चैनल आईडी से खोजें। तुरंत प्रीव्यू देखें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cari berdasarkan nama, @handle, atau ID saluran. Lihat pratinjau seketika."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名前、@handle、またはチャンネルIDで検索。すぐにプレビューを表示できます。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Атауы, @handle немесе арна ID-і бойынша іздеңіз. Алдын ала қарауды бірден көріңіз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6691,34 +7013,16 @@
             "value" : "பெயர், @handle அல்லது சேனல் ஐடி மூலம் தேடுங்கள். முன்னோட்டத்தை உடனே பாருங்கள்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "名前、@handle、またはチャンネルIDで検索。すぐにプレビューを表示できます。"
+            "value" : "Ad, @handle veya kanal kimliğine göre arayın. Önizlemeyi anında görün."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "按名称、@handle 或频道 ID 搜索，立即查看预览。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Атауы, @handle немесе арна ID-і бойынша іздеңіз. Алдын ала қарауды бірден көріңіз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cari berdasarkan nama, @handle, atau ID saluran. Lihat pratinjau seketika."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ad, @handle veya kanal kimliğine göre arayın. Önizlemeyi anında görün."
           }
         }
       }
@@ -6755,6 +7059,24 @@
             "value" : "अपना चैनल खोजें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cari saluran Anda"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを検索"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арнаңызды іздеңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6767,34 +7089,16 @@
             "value" : "உங்கள் சேனலைத் தேடுங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを検索"
+            "value" : "Kanalınızı arayın"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索您的频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арнаңызды іздеңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cari saluran Anda"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanalınızı arayın"
           }
         }
       }
@@ -6831,6 +7135,24 @@
             "value" : "अपने होम स्क्रीन या लॉक स्क्रीन पर सब्सक्राइबर और व्यू काउंट देखें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lihat jumlah subscriber dan tayangan di layar utama atau layar kunci Anda."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム画面やロック画面で登録者数と視聴回数を確認。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жазылушылар мен қаралым сандарын негізгі экранда немесе құлыптау экранында көріңіз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6843,34 +7165,16 @@
             "value" : "உங்கள் ஹோம் ஸ்கிரீன் அல்லது லாக் ஸ்கிரீனில் சந்தாதாரர் மற்றும் காட்சி எண்ணிக்கைகளைப் பாருங்கள்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ホーム画面やロック画面で登録者数と視聴回数を確認。"
+            "value" : "Ana ekranınızda veya kilit ekranınızda abone ve görüntülenme sayılarını görün."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "在主屏幕或锁定屏幕上查看订阅者数和观看次数。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жазылушылар мен қаралым сандарын негізгі экранда немесе құлыптау экранында көріңіз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lihat jumlah subscriber dan tayangan di layar utama atau layar kunci Anda."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ana ekranınızda veya kilit ekranınızda abone ve görüntülenme sayılarını görün."
           }
         }
       }
@@ -6907,6 +7211,24 @@
             "value" : "अपना चैनल चुनें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pilih Saluran Anda"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを選択してください"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арнаңызды таңдаңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6919,34 +7241,16 @@
             "value" : "உங்கள் சேனலைத் தெரிவு செய்க"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを選択してください"
+            "value" : "Kanalınızı Seçin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择您的频道"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арнаңызды таңдаңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pilih Saluran Anda"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanalınızı Seçin"
           }
         }
       }
@@ -6983,6 +7287,24 @@
             "value" : "सेटिंग्स"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pengaturan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Параметрлер"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6995,34 +7317,16 @@
             "value" : "அமைப்புகள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "設定"
+            "value" : "Ayarlar"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Параметрлер"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pengaturan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayarlar"
           }
         }
       }
@@ -7059,6 +7363,24 @@
             "value" : "अपडेट समय दिखाएं"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tampilkan Waktu Pembaruan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新時間を表示"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жаңарту уақытын көрсету"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7071,34 +7393,16 @@
             "value" : "புதுப்பிப்பு நேரத்தை காண்பி"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更新時間を表示"
+            "value" : "Güncelleme Zamanını Göster"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示更新时间"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жаңарту уақытын көрсету"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tampilkan Waktu Pembaruan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Güncelleme Zamanını Göster"
           }
         }
       }
@@ -7135,6 +7439,24 @@
             "value" : "संख्याओं को सरलीकृत करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sederhanakan Angka"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数字を単純化する"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сандарды жеңілдету"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7147,34 +7469,16 @@
             "value" : "எண்களை எளிமைப்படுத்து"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "数字を単純化する"
+            "value" : "Sayıları Basitleştirin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "简化数字"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сандарды жеңілдету"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sederhanakan Angka"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sayıları Basitleştirin"
           }
         }
       }
@@ -7211,6 +7515,24 @@
             "value" : "मुफ्त में शुरू करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MULAI GRATIS"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無料で始める"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ТЕГІН БАСТАУ"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7223,34 +7545,16 @@
             "value" : "இலவசமாக தொடங்குங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "無料で始める"
+            "value" : "ÜCRETSİZ BAŞLA"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "免费开始"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ТЕГІН БАСТАУ"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "MULAI GRATIS"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ÜCRETSİZ BAŞLA"
           }
         }
       }
@@ -7287,6 +7591,24 @@
             "value" : "सबमिट करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kirim"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "送信する"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жіберу"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7299,34 +7621,16 @@
             "value" : "சமர்ப்பிக்கவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "送信する"
+            "value" : "Gönder"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "提交"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жіберу"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kirim"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gönder"
           }
         }
       }
@@ -7363,6 +7667,24 @@
             "value" : "सब्सक्राइबर + व्यूज़"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subscriber + Tayangan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登録者数 + 視聴回数"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жазылушылар + қаралымдар"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7375,34 +7697,16 @@
             "value" : "சந்தாதாரர்கள் + பார்வைகள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "登録者数 + 視聴回数"
+            "value" : "Aboneler + Görüntülemeler"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "订阅者数 + 观看次数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жазылушылар + қаралымдар"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Subscriber + Tayangan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aboneler + Görüntülemeler"
           }
         }
       }
@@ -7439,6 +7743,24 @@
             "value" : "SubWidget"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ザザップザザ"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7451,31 +7773,13 @@
             "value" : "SubWidget"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ザザップザザ"
+            "value" : "SubWidget"
           }
         },
         "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget"
-          }
-        },
-        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SubWidget"
@@ -7515,6 +7819,24 @@
             "value" : "SubWidget %@"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ザザッザッザッザッザッザッザッ"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget %@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7527,31 +7849,13 @@
             "value" : "SubWidget %@"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ザザッザッザッザッザッザッザッ"
+            "value" : "SubWidget %@"
           }
         },
         "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget %@"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget %@"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget %@"
-          }
-        },
-        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SubWidget %@"
@@ -7591,6 +7895,24 @@
             "value" : "SubWidget सामान्य प्रश्न"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget FAQ"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget よくある質問"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget ЖҚС"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7603,34 +7925,16 @@
             "value" : "சப்விஜெட் அடிக்கடி கேட்கப்படும் கேள்விகள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "SubWidget よくある質問"
+            "value" : "SubWidget SSS"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SubWidget 常见问题解答"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget ЖҚС"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget FAQ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget SSS"
           }
         }
       }
@@ -7667,6 +7971,24 @@
             "value" : "SubWidget Pro"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget Pro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget Pro"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget Pro"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7679,31 +8001,13 @@
             "value" : "SubWidget Pro"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SubWidget Pro"
           }
         },
         "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget Pro"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget Pro"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget Pro"
-          }
-        },
-        "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SubWidget Pro"
@@ -7743,6 +8047,24 @@
             "value" : "चैनल को हटाने के लिए उस पर दाईं ओर स्वाइप करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geser ke kanan pada saluran untuk menghapusnya"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルを右にスワイプして削除します"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оны жою үшін арнаны оңға сырғытыңыз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7755,34 +8077,16 @@
             "value" : "சேனலை நீக்க அதில் வலமாக ஸ்வைப் செய்யவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルを右にスワイプして削除します"
+            "value" : "Silmek için kanalı sağa kaydırın"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "向右滑动频道即可将其删除"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Оны жою үшін арнаны оңға сырғытыңыз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geser ke kanan pada saluran untuk menghapusnya"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Silmek için kanalı sağa kaydırın"
           }
         }
       }
@@ -7819,6 +8123,24 @@
             "value" : "अपनी होमस्क्रीन पर कहीं भी टैप करके रखें और ऊपर बाईं ओर प्लस बटन पर टैप करें। SubWidget को खोजें और उसे अपनी होमस्क्रीन पर जोड़ें। अंत में, विजेट पर टैप करके रखें और अपना चैनल चुनें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketuk dan tahan di mana saja di layar beranda Anda dan ketuk tombol plus di kiri atas. Cari SubWidget dan tambahkan ke layar beranda Anda. Terakhir, ketuk dan tahan widget dan pilih saluran Anda."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム画面の任意の場所を長押しし、左上のプラスボタンをタップします。 SubWidget を探してホーム画面に追加します。最後に、ウィジェットを長押ししてチャンネルを選択します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Негізгі экранның кез келген жерін түртіп, ұстап тұрыңыз және жоғарғы сол жақтағы қосу түймесін түртіңіз. SubWidget іздеп, оны негізгі экранға қосыңыз. Соңында виджетті түртіп, ұстап тұрыңыз және арнаңызды таңдаңыз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7831,34 +8153,16 @@
             "value" : "உங்கள் முகப்புத் திரையில் எங்கும் தட்டி அழுத்தி, மேல் இடதுபுறத்தில் உள்ள பிளஸ் பட்டனை தட்டவும். SubWidget ஐத் தேடி உங்கள் முகப்புத் திரையில் சேர்க்கவும். இறுதியாக, விஜெட்டின் மீது தட்டி அழுத்தி உங்கள் சேனலைத் தெரிவு செய்க."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ホーム画面の任意の場所を長押しし、左上のプラスボタンをタップします。 SubWidget を探してホーム画面に追加します。最後に、ウィジェットを長押ししてチャンネルを選択します。"
+            "value" : "Ana ekranınızda herhangi bir yere dokunup basılı tutun ve sol üstteki artı düğmesine dokunun. SubWidget'i arayın ve ana ekranınıza ekleyin. Son olarak widget'a dokunup basılı tutun ve kanalınızı seçin."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "点击并按住主屏幕上的任意位置，然后点击左上角的加号按钮。查找 SubWidget 并将其添加到您的主屏幕。最后，点击并按住小组件并选择您的频道。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Негізгі экранның кез келген жерін түртіп, ұстап тұрыңыз және жоғарғы сол жақтағы қосу түймесін түртіңіз. SubWidget іздеп, оны негізгі экранға қосыңыз. Соңында виджетті түртіп, ұстап тұрыңыз және арнаңызды таңдаңыз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ketuk dan tahan di mana saja di layar beranda Anda dan ketuk tombol plus di kiri atas. Cari SubWidget dan tambahkan ke layar beranda Anda. Terakhir, ketuk dan tahan widget dan pilih saluran Anda."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ana ekranınızda herhangi bir yere dokunup basılı tutun ve sol üstteki artı düğmesine dokunun. SubWidget'i arayın ve ana ekranınıza ekleyin. Son olarak widget'a dokunup basılı tutun ve kanalınızı seçin."
           }
         }
       }
@@ -7895,6 +8199,24 @@
             "value" : "चैनल लोड नहीं हो रहे हैं।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saluran tidak dimuat."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネルが読み込まれていません。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арналар жүктелмейді."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7907,34 +8229,16 @@
             "value" : "சேனல்கள் ஏற்றப்படவில்லை."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネルが読み込まれていません。"
+            "value" : "Kanallar yüklenmiyor."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "频道未加载。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арналар жүктелмейді."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saluran tidak dimuat."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanallar yüklenmiyor."
           }
         }
       }
@@ -7971,6 +8275,24 @@
             "value" : "विजेट खाली है।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widgetnya kosong."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットは空白です。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджет бос."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7983,34 +8305,16 @@
             "value" : "விஜெட்டு காலியாக உள்ளது."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ウィジェットは空白です。"
+            "value" : "Widget boş."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "小组件是空白的。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджет бос."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widgetnya kosong."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget boş."
           }
         }
       }
@@ -8047,6 +8351,24 @@
             "value" : "यह एक सर्वर समस्या को दर्शाता है। कृपया बाद में पुनः प्रयास करें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ini menunjukkan masalah server. Silakan coba lagi nanti."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "これはサーバーの問題を示しています。後でもう一度試してください。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бұл сервер мәселесін көрсетеді. Тағы жасауды сәл кейінірек көріңізді өтінеміз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8059,34 +8381,16 @@
             "value" : "இது ஒரு சேவையக சிக்கலை குறிக்கிறது. தயவுசெய்து பின்னர் முயற்சிக்கவும்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "これはサーバーの問題を示しています。後でもう一度試してください。"
+            "value" : "Bu bir sunucu sorununu gösterir. Lütfen daha sonra tekrar deneyin."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "这表明服务器有问题。请稍后重试。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Бұл сервер мәселесін көрсетеді. Тағы жасауды сәл кейінірек көріңізді өтінеміз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ini menunjukkan masalah server. Silakan coba lagi nanti."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu bir sunucu sorununu gösterir. Lütfen daha sonra tekrar deneyin."
           }
         }
       }
@@ -8123,6 +8427,24 @@
             "value" : "कुल सब्सक्राइबर"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah subscriber"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "総登録者数"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жалпы жазылушылар саны"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8135,34 +8457,16 @@
             "value" : "மொத்த சந்தாதாரர்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "総登録者数"
+            "value" : "Toplam abone sayısı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "订阅者总数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жалпы жазылушылар саны"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jumlah subscriber"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toplam abone sayısı"
           }
         }
       }
@@ -8199,6 +8503,24 @@
             "value" : "कुल दृश्य"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jumlah tayangan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "総視聴回数"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жалпы қаралым саны"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8211,34 +8533,16 @@
             "value" : "மொத்த காட்சிகள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "総視聴回数"
+            "value" : "Toplam görüntüleme sayısı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "总观看次数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жалпы қаралым саны"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jumlah tayangan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toplam görüntüleme sayısı"
           }
         }
       }
@@ -8275,6 +8579,24 @@
             "value" : "पुनः प्रयास करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coba Lagi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "もう一度試してください"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қайталап көріңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8287,34 +8609,16 @@
             "value" : "மீண்டும் முயற்சிக்கவும்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "もう一度試してください"
+            "value" : "Tekrar Deneyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "再试一次"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қайталап көріңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coba Lagi"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tekrar Deneyin"
           }
         }
       }
@@ -8351,6 +8655,24 @@
             "value" : "अपने चैनल के नाम के बजाय अपनी चैनल आईडी दर्ज करने का प्रयास करें। यदि वह अभी भी काम नहीं करता है, तो कृपया मुझसे संपर्क करें और मैं आपकी मदद करूंगा।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coba masukkan ID saluran Anda, bukan nama saluran Anda. Jika masih tidak berhasil, silakan hubungi saya dan saya akan membantu Anda."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャンネル名の代わりにチャンネル ID を入力してみてください。それでもうまくいかない場合は、私に連絡してください。お手伝いします。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Арна атауының орнына арна идентификаторын енгізіп көріңіз. Егер бұл әлі жұмыс істемесе, маған хабарласыңыз, мен сізге көмектесемін."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8363,34 +8685,16 @@
             "value" : "உங்கள் சேனல் பெயருக்கு பதிலாக உங்கள் சேனல் ஐடியை உள்ளிட முயற்சிக்கவும். அதுவும் செயல்படவில்லை என்றால், தயவுசெய்து என்னை தொடர்பு கொள்ளவும், நான் உதவுவேன்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャンネル名の代わりにチャンネル ID を入力してみてください。それでもうまくいかない場合は、私に連絡してください。お手伝いします。"
+            "value" : "Kanal adınız yerine kanal kimliğinizi girmeyi deneyin. Eğer hala işe yaramazsa lütfen benimle iletişime geçin, size yardımcı olacağım."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "尝试输入您的频道 ID 而不是频道名称。如果仍然不行，请联系我，我会帮助你。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Арна атауының орнына арна идентификаторын енгізіп көріңіз. Егер бұл әлі жұмыс істемесе, маған хабарласыңыз, мен сізге көмектесемін."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coba masukkan ID saluran Anda, bukan nama saluran Anda. Jika masih tidak berhasil, silakan hubungi saya dan saya akan membantu Anda."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kanal adınız yerine kanal kimliğinizi girmeyi deneyin. Eğer hala işe yaramazsa lütfen benimle iletişime geçin, size yardımcı olacağım."
           }
         }
       }
@@ -8427,6 +8731,24 @@
             "value" : "इसके बजाय अपना चैनल आईडी दर्ज करने का प्रयास करें। यदि यह काम नहीं करता है, तो कृपया अपनी चैनल URL के साथ मुझसे संपर्क करें, मैं इसे ढूँढने में आपकी सहायता करूँगा।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coba masukkan ID saluran Anda. Jika tidak berhasil, silakan hubungi saya dengan URL saluran Anda dan saya akan membantu Anda menemukannya"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "代わりにチャンネル ID を入力してみてください。それでもうまくいかない場合は、チャンネルの URL をお知らせください。見つけるお手伝いをいたします。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оның орнына арна идентификаторын енгізіп көріңіз. Егер бұл жұмыс істемесе, арнаңыздың URL мекенжайы бойынша маған хабарласыңыз, мен сізге оны табуға көмектесемін"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8439,34 +8761,16 @@
             "value" : "அதற்கு பதிலாக உங்கள் சேனல் ஐடியை உள்ளிட முயற்சிக்கவும். அது வேலை செய்யவில்லை என்றால், உங்கள் சேனல் URL உடன் என்னை தொடர்புகொள்ளுங்கள்; அதை கண்டுபிடிக்க நான் உதவுவேன்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "代わりにチャンネル ID を入力してみてください。それでもうまくいかない場合は、チャンネルの URL をお知らせください。見つけるお手伝いをいたします。"
+            "value" : "Bunun yerine kanal kimliğinizi girmeyi deneyin. Bu işe yaramazsa lütfen kanal URL'nizle birlikte benimle iletişime geçin; bulmanıza yardımcı olacağım"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "请尝试输入您的频道 ID。如果这不起作用，请与我联系并提供您的频道网址，我会帮助您找到它"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Оның орнына арна идентификаторын енгізіп көріңіз. Егер бұл жұмыс істемесе, арнаңыздың URL мекенжайы бойынша маған хабарласыңыз, мен сізге оны табуға көмектесемін"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coba masukkan ID saluran Anda. Jika tidak berhasil, silakan hubungi saya dengan URL saluran Anda dan saya akan membantu Anda menemukannya"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bunun yerine kanal kimliğinizi girmeyi deneyin. Bu işe yaramazsa lütfen kanal URL'nizle birlikte benimle iletişime geçin; bulmanıza yardımcı olacağım"
           }
         }
       }
@@ -8503,6 +8807,24 @@
             "value" : "गोधूलि"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senja"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トワイライト"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ымырт"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8515,34 +8837,16 @@
             "value" : "சந்திப்பு நேரம்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "トワイライト"
+            "value" : "Alacakaranlık"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "暮光之城"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ымырт"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Senja"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alacakaranlık"
           }
         }
       }
@@ -8579,6 +8883,24 @@
             "value" : "दुर्भाग्यवश, YouTube सटीक सब्सक्राइबर गिनती प्रदान नहीं करता है, वे एक गोल नंबर प्रदान करते हैं।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sayangnya YouTube tidak memberikan jumlah pasti subscribernya, mereka memberikan angka yang dibulatkan."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "残念ながら、YouTube は正確な登録者数を提供しておらず、概数を提供しています。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Өкінішке орай, YouTube жазылушылардың нақты санын бермейді, олар дөңгелектелген нөмірді береді."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8591,34 +8913,16 @@
             "value" : "துரதிருஷ்டவசமாக, YouTube குறிப்பிட்ட சந்தாதாரர் எண்ணிக்கையை வழங்காமல், ஒரு சுற்று எண்ணை வழங்குகிறது."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "残念ながら、YouTube は正確な登録者数を提供しておらず、概数を提供しています。"
+            "value" : "Ne yazık ki YouTube tam abone sayısını vermiyor; yuvarlatılmış bir sayı veriyor."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "不幸的是，YouTube 不提供准确的订阅者数量，他们提供的是四舍五入的数字。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Өкінішке орай, YouTube жазылушылардың нақты санын бермейді, олар дөңгелектелген нөмірді береді."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sayangnya YouTube tidak memberikan jumlah pasti subscribernya, mereka memberikan angka yang dibulatkan."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ne yazık ki YouTube tam abone sayısını vermiyor; yuvarlatılmış bir sayı veriyor."
           }
         }
       }
@@ -8655,6 +8959,24 @@
             "value" : "अनलॉक करें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka kunci"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロックを解除する"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Құлыпты ашу"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8667,34 +8989,16 @@
             "value" : "திற"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ロックを解除する"
+            "value" : "Kilidi aç"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "解锁"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Құлыпты ашу"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buka kunci"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kilidi aç"
           }
         }
       }
@@ -8731,6 +9035,24 @@
             "value" : "अपडेट आवृत्ति"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frekuensi Pembaruan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新頻度"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жаңарту жиілігі"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8743,34 +9065,16 @@
             "value" : "புதுப்பிப்பு அதிர்வெண்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更新頻度"
+            "value" : "Güncelleme Sıklığı"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新频率"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жаңарту жиілігі"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frekuensi Pembaruan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Güncelleme Sıklığı"
           }
         }
       }
@@ -8807,6 +9111,24 @@
             "value" : "एक ही विजेट में अपने सब्सक्राइबर और व्यू की संख्या देखें"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lihat jumlah subscriber dan tayangan dalam satu widget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1つのウィジェットで登録者数と視聴回数をまとめて表示"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бір виджетте жазылушылар мен қаралым санын бірге көріңіз"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8819,34 +9141,16 @@
             "value" : "ஒரே விட்ஜெட்டில் உங்கள் சந்தாதாரர்கள் மற்றும் பார்வைகள் எண்ணிக்கையை காணுங்கள்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1つのウィジェットで登録者数と視聴回数をまとめて表示"
+            "value" : "Abone ve görüntülenme sayılarını tek bir widget'ta birlikte görüntüleyin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "在一个小组件中同时查看订阅者数和观看次数"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Бір виджетте жазылушылар мен қаралым санын бірге көріңіз"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lihat jumlah subscriber dan tayangan dalam satu widget"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abone ve görüntülenme sayılarını tek bir widget'ta birlikte görüntüleyin"
           }
         }
       }
@@ -8883,6 +9187,24 @@
             "value" : "रीसेट बटन क्या करता है?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apa fungsi tombol reset?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リセットボタンは何をするのですか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қалпына келтіру түймесі не істейді?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8895,34 +9217,16 @@
             "value" : "மீட்டமைப்பு பொத்தான் என்ன செய்கிறது?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リセットボタンは何をするのですか?"
+            "value" : "Sıfırlama düğmesi ne işe yarar?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置按钮有什么作用？"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қалпына келтіру түймесі не істейді?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apa fungsi tombol reset?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sıfırlama düğmesi ne işe yarar?"
           }
         }
       }
@@ -8959,6 +9263,24 @@
             "value" : "SubWidget में क्या नया है"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apa yang Baru di SubWidget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget の新機能"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget қолданбасында қандай жаңалықтар бар"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8971,34 +9293,16 @@
             "value" : "சப்விஜெட்டில் புதியது என்ன?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "SubWidget の新機能"
+            "value" : "SubWidget'deki Yenilikler"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "SubWidget 的新功能"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget қолданбасында қандай жаңалықтар бар"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apa yang Baru di SubWidget"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget'deki Yenilikler"
           }
         }
       }
@@ -9035,6 +9339,24 @@
             "value" : "यह सटीक सब्सक्राइबर गिनती क्यों नहीं दिखाता है?"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengapa tidak menunjukkan jumlah pasti pelanggan?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正確なチャンネル登録者数が表示されないのはなぜですか?"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неліктен ол жазылушылардың нақты санын көрсетпейді?"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9047,10 +9369,10 @@
             "value" : "ஏன் அது குறிப்பிட்ட சந்தாதாரர் எண்ணிக்கையை காட்டவில்லை?"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正確なチャンネル登録者数が表示されないのはなぜですか?"
+            "value" : "Neden tam abone sayısını göstermiyor?"
           }
         },
         "zh-Hans" : {
@@ -9058,23 +9380,81 @@
             "state" : "translated",
             "value" : "为什么它不显示确切的订阅者数量？"
           }
-        },
-        "kk" : {
+        }
+      }
+    },
+    "Widget Kind" : {
+      "localizations" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Неліктен ол жазылушылардың нақты санын көрсетпейді?"
+            "value" : "نوع الأداة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget-Typ"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de widget"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type de widget"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विजेट प्रकार"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mengapa tidak menunjukkan jumlah pasti pelanggan?"
+            "value" : "Jenis Widget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットの種類"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджет түрі"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de widget"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "விட்ஜெட் வகை"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Neden tam abone sayısını göstermiyor?"
+            "value" : "Widget Türü"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小组件类型"
           }
         }
       }
@@ -9111,6 +9491,24 @@
             "value" : "विशलिस्ट"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daftar Keinginan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィッシュリスト"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қалаулар тізімі"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9123,34 +9521,16 @@
             "value" : "விருப்பப் பட்டியல்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ウィッシュリスト"
+            "value" : "İstek Listesi"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "愿望清单"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Қалаулар тізімі"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Daftar Keinginan"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İstek Listesi"
           }
         }
       }
@@ -9187,6 +9567,24 @@
             "value" : "SubWidget Pro के साथ, आप 10 तक चैनल जोड़ सकते हैं। यदि आप इससे अधिक जोड़ना चाहते हैं, तो सेटिंग्स में दिए गए लिंक से मुझसे संपर्क करें और मैं सीमा बढ़ा दूंगा।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dengan SubWidget Pro, Anda dapat menambahkan hingga 10 saluran. Jika Anda ingin menambahkan lebih banyak, silakan hubungi saya menggunakan tautan di Pengaturan dan saya akan menambah batasnya."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget Pro では、最大 10 チャンネルを追加できます。さらに追加したい場合は、設定のリンクを使用して私にご連絡ください。制限を増やします。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget Pro көмегімен 10 арнаға дейін қосуға болады. Қосымша қосқыңыз келсе, \"Параметрлер\" бөліміндегі сілтеме арқылы маған хабарласыңыз, мен шектеуді арттырамын."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9199,34 +9597,16 @@
             "value" : "SubWidget Pro உடன், நீங்கள் 10 சேனல்கள் வரை சேர்க்கலாம். அதற்கு மேல் சேர்க்க விரும்பினால், அமைப்புகளில் உள்ள இணைப்பைப் பயன்படுத்தி என்னை தொடர்பு கொள்ளுங்கள்; நான் வரம்பை உயர்த்துவேன்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "SubWidget Pro では、最大 10 チャンネルを追加できます。さらに追加したい場合は、設定のリンクを使用して私にご連絡ください。制限を増やします。"
+            "value" : "SubWidget Pro ile 10'a kadar kanal ekleyebilirsiniz. Daha fazlasını eklemek isterseniz lütfen Ayarlar'daki bağlantıyı kullanarak benimle iletişime geçin; limiti artıracağım."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用 SubWidget Pro，您最多可以添加 10 个频道。如果您想添加更多，请使用“设置”中的链接与我联系，我将增加限制。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget Pro көмегімен 10 арнаға дейін қосуға болады. Қосымша қосқыңыз келсе, \"Параметрлер\" бөліміндегі сілтеме арқылы маған хабарласыңыз, мен шектеуді арттырамын."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dengan SubWidget Pro, Anda dapat menambahkan hingga 10 saluran. Jika Anda ingin menambahkan lebih banyak, silakan hubungi saya menggunakan tautan di Pengaturan dan saya akan menambah batasnya."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SubWidget Pro ile 10'a kadar kanal ekleyebilirsiniz. Daha fazlasını eklemek isterseniz lütfen Ayarlar'daki bağlantıyı kullanarak benimle iletişime geçin; limiti artıracağım."
           }
         }
       }
@@ -9263,6 +9643,24 @@
             "value" : "आप केवल 10 चैनल जोड़ सकते हैं। एक चैनल को हटाने के लिए बाईं ओर स्वाइप करें।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda hanya dapat menambahkan 10 saluran. Gesek ke kiri pada saluran untuk menghapusnya."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加できるチャンネルは 10 個までです。チャンネルを左にスワイプして削除します。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сіз тек 10 арна қоса аласыз. Арнаны жою үшін оны солға сырғытыңыз."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9275,34 +9673,16 @@
             "value" : "நீங்கள் 10 சேனல்கள் மட்டுமே சேர்க்கலாம். சேனலை நீக்க இடதுபுறமாக ஸ்வைப் செய்யவும்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "追加できるチャンネルは 10 個までです。チャンネルを左にスワイプして削除します。"
+            "value" : "Yalnızca 10 kanal ekleyebilirsiniz. Silmek için bir kanalı sola kaydırın."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "您只能添加 10 个频道。在频道上向左滑动即可将其删除。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сіз тек 10 арна қоса аласыз. Арнаны жою үшін оны солға сырғытыңыз."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anda hanya dapat menambahkan 10 saluran. Gesek ke kiri pada saluran untuk menghapusnya."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yalnızca 10 kanal ekleyebilirsiniz. Silmek için bir kanalı sola kaydırın."
           }
         }
       }
@@ -9339,6 +9719,24 @@
             "value" : "आप नीचे दिए गए विशलिस्ट टैब का उपयोग करके एक फीचर का अनुरोध कर सकते हैं।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda dapat meminta fitur menggunakan tab Daftar Keinginan di bawah."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以下の「ウィッシュリスト」タブを使用して機能をリクエストできます。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Төмендегі Қалаулар тізімі қойындысын пайдаланып мүмкіндікті сұрауға болады."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9351,34 +9749,16 @@
             "value" : "நீங்கள் கீழே உள்ள Wishlist தாவலைப் பயன்படுத்தி ஒரு அம்சத்தை கோரலாம்."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "以下の「ウィッシュリスト」タブを使用して機能をリクエストできます。"
+            "value" : "Aşağıdaki İstek Listesi sekmesini kullanarak bir özellik talep edebilirsiniz."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "您可以使用下面的“愿望清单”选项卡来请求某项功能。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Төмендегі Қалаулар тізімі қойындысын пайдаланып мүмкіндікті сұрауға болады."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anda dapat meminta fitur menggunakan tab Daftar Keinginan di bawah."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aşağıdaki İstek Listesi sekmesini kullanarak bir özellik talep edebilirsiniz."
           }
         }
       }
@@ -9415,6 +9795,24 @@
             "value" : "आप ऐप सेटिंग्स में विजेट को कितनी बार अपडेट करना चाहते हैं, यह चुन सकते हैं। न्यूनतम हर 30 मिनट है।"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda dapat memilih seberapa sering Anda ingin widget diperbarui di pengaturan aplikasi. Minimalnya setiap 30 menit."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリ設定でウィジェットを更新する頻度を選択できます。最小値は 30 分ごとです。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджеттің қаншалықты жиі жаңартылатынын қолданба параметрлерінде таңдауға болады. Минималды - әр 30 минут сайын."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9427,34 +9825,16 @@
             "value" : "நீங்கள் செயலி அமைப்புகளில் விஜெட்டு எவ்வளவு அடிக்கடி புதுப்பிக்கப்பட வேண்டும் என்பதை தெரிவு செய்யலாம். குறைந்தபட்சம் ஒவ்வொரு 30 நிமிடங்களுக்கும் உள்ளது."
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アプリ設定でウィジェットを更新する頻度を選択できます。最小値は 30 分ごとです。"
+            "value" : "Widget'ın ne sıklıkta güncellenmesini istediğinizi uygulama ayarlarından seçebilirsiniz. Minimum her 30 dakikada birdir."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "您可以在应用程序设置中选择小组件的更新频率。最少为每 30 分钟一次。"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Виджеттің қаншалықты жиі жаңартылатынын қолданба параметрлерінде таңдауға болады. Минималды - әр 30 минут сайын."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anda dapat memilih seberapa sering Anda ingin widget diperbarui di pengaturan aplikasi. Minimalnya setiap 30 menit."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Widget'ın ne sıklıkta güncellenmesini istediğinizi uygulama ayarlarından seçebilirsiniz. Minimum her 30 dakikada birdir."
           }
         }
       }
@@ -9491,6 +9871,24 @@
             "value" : "जब यह चैनल %@ सब्सक्राइबर तक पहुंचेगा, तब आपको सूचित किया जाएगा!"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anda akan diberi tahu saat saluran ini mencapai %@ subscriber!"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このチャンネルが %@ 人の登録者に達すると通知されます！"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бұл арна %@ жазылушыға жеткенде сізге хабарланады!"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9503,34 +9901,16 @@
             "value" : "இந்த சேனல் %@ சந்தாதாரர்களை எட்டும் போது உங்களுக்கு அறிவிக்கப்படும்!"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このチャンネルが %@ 人の登録者に達すると通知されます！"
+            "value" : "Bu kanal %@ aboneye ulaştığında bilgilendirileceksiniz!"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "当此频道达到 %@ 位订阅者时，你会收到通知！"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Бұл арна %@ жазылушыға жеткенде сізге хабарланады!"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anda akan diberi tahu saat saluran ini mencapai %@ subscriber!"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu kanal %@ aboneye ulaştığında bilgilendirileceksiniz!"
           }
         }
       }
@@ -9567,6 +9947,24 @@
             "value" : "YouTube चैनल आँकड़े, एक नज़र में"
           }
         },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sekilas tentang statistik saluran YouTube"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube チャンネル統計の概要"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube арнасының статистикасы, бір қарағанда"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9579,34 +9977,16 @@
             "value" : "YouTube சேனல் புள்ளிவிவரங்கள், ஒரே பார்வையில்"
           }
         },
-        "ja" : {
+        "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "YouTube チャンネル統計の概要"
+            "value" : "Bir bakışta YouTube kanal istatistikleri"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "YouTube 频道统计数据一目了然"
-          }
-        },
-        "kk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "YouTube арнасының статистикасы, бір қарағанда"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sekilas tentang statistik saluran YouTube"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bir bakışta YouTube kanal istatistikleri"
           }
         }
       }

--- a/SubscriberWidget/Services/AnalyticsService.swift
+++ b/SubscriberWidget/Services/AnalyticsService.swift
@@ -104,6 +104,18 @@ class AnalyticsService {
         ])
     }
 
+    func logWidgetRefreshButtonToggled(_ isToggled: Bool) {
+        logEvent("widget_refresh_button.toggled", properties: [
+            "isToggled": isToggled
+        ])
+    }
+
+    func logWidgetManualRefreshTapped(widgetKind: String) {
+        logEvent("widget_manual_refresh.tapped", properties: [
+            "widgetKind": widgetKind
+        ])
+    }
+
     func logFaqScreenViewed() {
         logEvent("faq_screen.viewed")
     }

--- a/SubscriberWidget/Services/YouTubeService.swift
+++ b/SubscriberWidget/Services/YouTubeService.swift
@@ -14,8 +14,8 @@ class YouTubeService: YouTubeServiceProtocol {
     let storage: Storage<String, YouTubeChannel>?
 
     init() {
-        let diskConfig = DiskConfig(name: "SubWidget", expiry: .seconds(600))
-        let memoryConfig = MemoryConfig(expiry: .seconds(600))
+        let diskConfig = DiskConfig(name: "SubWidget", expiry: .seconds(120))
+        let memoryConfig = MemoryConfig(expiry: .seconds(120))
 
         self.storage = try? Storage(
             diskConfig: diskConfig,

--- a/SubscriberWidget/View/SettingsView/SettingsView.swift
+++ b/SubscriberWidget/View/SettingsView/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
     @Environment(\.colorScheme) var colorScheme
     @AppStorage("simplifyNumbers", store: .shared) var simplifyNumbers: Bool = false
     @AppStorage("showUpdateTime", store: .shared) var showUpdateTime: Bool = true
+    @AppStorage("showWidgetRefreshButton", store: .shared) var showWidgetRefreshButton: Bool = false
     @AppStorage("hasProAccess", store: .shared) var hasProAccess: Bool = false
     @State private var showPaywall = false
 
@@ -112,6 +113,28 @@ struct SettingsView: View {
                                 return
                             }
                             AnalyticsService.shared.logSimplifyNumbersToggled(newValue)
+                            WidgetCenter.shared.reloadAllTimelines()
+                        }
+                    }
+
+                    Section(footer: Text("Add a button to manually refresh the subscriber count")) {
+                        Toggle(isOn: $showWidgetRefreshButton) {
+                            Label {
+                                Text("Refresh Button")
+                            } icon: {
+                                Image(systemName: "arrow.clockwise.circle.fill")
+                                    .foregroundStyle(.white, Color.youtubeRed)
+                            }
+                        }
+                        .tint(.youtubeRed)
+                        .onChange(of: showWidgetRefreshButton) { newValue in
+                            if !hasProAccess && newValue {
+                                showWidgetRefreshButton = false
+                                AnalyticsService.shared.logPaywallShown(source: "widget_refresh_button")
+                                showPaywall = true
+                                return
+                            }
+                            AnalyticsService.shared.logWidgetRefreshButtonToggled(newValue)
                             WidgetCenter.shared.reloadAllTimelines()
                         }
                     }


### PR DESCRIPTION
## Summary
- add a Pro-only refresh button option for small and medium widgets
- add the widget refresh intent and analytics for manual refresh usage
- update localized strings for the new refresh UI and intent copy
- include the reduced YouTube cache duration change

## Testing
- manually verified in Xcode that the refresh button appears and works after clearing the known duplicate `Base.lproj` build-phase entries
- command-line `xcodebuild` remains blocked by the pre-existing duplicate localized resource task issue
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arjun-dureja/subwidget/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
