### PR TITLE
Add lightweight review prompt manager

### DIFF
--- a/SubscriberWidget/SceneDelegate.swift
+++ b/SubscriberWidget/SceneDelegate.swift
@@ -78,6 +78,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
+        ReviewPromptService.shared.registerAppOpen()
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/SubscriberWidget/SceneDelegate.swift
+++ b/SubscriberWidget/SceneDelegate.swift
@@ -78,13 +78,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        ReviewPromptService.shared.registerAppOpen()
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
+        ReviewPromptService.shared.registerAppOpen()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/SubscriberWidget/Services/ReviewPromptService.swift
+++ b/SubscriberWidget/Services/ReviewPromptService.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import Foundation
 
+@MainActor
 final class ReviewPromptService {
     static let shared = ReviewPromptService()
 
@@ -36,7 +37,6 @@ final class ReviewPromptService {
         hasTappedRateButton = true
     }
 
-    @MainActor
     func requestReviewIfAppropriate(channelCount: Int, requestReview: () -> Void) {
         guard shouldRequestReview(channelCount: channelCount) else { return }
 

--- a/SubscriberWidget/Services/ReviewPromptService.swift
+++ b/SubscriberWidget/Services/ReviewPromptService.swift
@@ -1,0 +1,61 @@
+//
+//  ReviewPromptService.swift
+//  SubscriberWidget
+//
+//  Created by OpenAI on 2026-03-14.
+//
+
+import SwiftUI
+import Foundation
+
+final class ReviewPromptService {
+    static let shared = ReviewPromptService()
+
+    @AppStorage("reviewPromptRequestCount", store: .shared) private var requestCount: Int = 0
+    @AppStorage("reviewPromptLastRequestedTimestamp", store: .shared) private var lastRequestedTimestamp: Double = 0
+    @AppStorage("reviewPromptHasTappedRateButton", store: .shared) private var hasTappedRateButton: Bool = false
+
+    private var didShowPaywallThisSession = false
+    private var didRequestReviewThisSession = false
+
+    private let maxRequestCount = 3
+    private let cooldown: TimeInterval = 30 * 24 * 60 * 60
+
+    private init() {}
+
+    func registerAppOpen() {
+        didShowPaywallThisSession = false
+        didRequestReviewThisSession = false
+    }
+
+    func markPaywallShown() {
+        didShowPaywallThisSession = true
+    }
+
+    func markRateButtonTapped() {
+        hasTappedRateButton = true
+    }
+
+    @MainActor
+    func requestReviewIfAppropriate(channelCount: Int, requestReview: () -> Void) {
+        guard shouldRequestReview(channelCount: channelCount) else { return }
+
+        didRequestReviewThisSession = true
+        requestCount += 1
+        lastRequestedTimestamp = Date().timeIntervalSince1970
+
+        AnalyticsService.shared.logReviewRequested()
+        requestReview()
+    }
+
+    private func shouldRequestReview(channelCount: Int) -> Bool {
+        guard channelCount >= 1 else { return false }
+        guard !hasTappedRateButton else { return false }
+        guard !didShowPaywallThisSession else { return false }
+        guard !didRequestReviewThisSession else { return false }
+        guard requestCount < maxRequestCount else { return false }
+
+        guard lastRequestedTimestamp > 0 else { return true }
+        return Date().timeIntervalSince1970 - lastRequestedTimestamp >= cooldown
+    }
+}

--- a/SubscriberWidget/View/MainView.swift
+++ b/SubscriberWidget/View/MainView.swift
@@ -129,7 +129,6 @@ struct MainView: View {
     private func prepareInitialPresentation() async {
         guard !hasPreparedInitialPresentation else { return }
         hasPreparedInitialPresentation = true
-        ReviewPromptService.shared.registerAppOpen()
 
         await SubscriptionService().checkAccess()
         let hasSavedChannels = !ChannelStorageService().getChannels().isEmpty

--- a/SubscriberWidget/View/MainView.swift
+++ b/SubscriberWidget/View/MainView.swift
@@ -129,6 +129,7 @@ struct MainView: View {
     private func prepareInitialPresentation() async {
         guard !hasPreparedInitialPresentation else { return }
         hasPreparedInitialPresentation = true
+        ReviewPromptService.shared.registerAppOpen()
 
         await SubscriptionService().checkAccess()
         let hasSavedChannels = !ChannelStorageService().getChannels().isEmpty

--- a/SubscriberWidget/View/SettingsView/SettingsView.swift
+++ b/SubscriberWidget/View/SettingsView/SettingsView.swift
@@ -167,6 +167,7 @@ struct SettingsView: View {
 
                         Button {
                             AnalyticsService.shared.logRateButtontapped()
+                            ReviewPromptService.shared.markRateButtonTapped()
                             UIApplication.shared.open(URL(string: "https://itunes.apple.com/app/id1534958933?action=write-review")!)
                         } label: {
                             FormLabel(text: "Rate", icon: "star.circle.fill")

--- a/SubscriberWidget/View/View+Extensions.swift
+++ b/SubscriberWidget/View/View+Extensions.swift
@@ -21,6 +21,9 @@ extension View {
         self.sheet(isPresented: isPresented) {
             NavigationView {
                 PaywallView()
+                    .onAppear {
+                        ReviewPromptService.shared.markPaywallShown()
+                    }
                     .onPurchaseCompleted { _, _ in
                         AnalyticsService.shared.logSubscriptionPurchaseCompleted()
                         Task { await SubscriptionService().checkAccess() }

--- a/SubscriberWidget/View/WidgetListView/WidgetListView.swift
+++ b/SubscriberWidget/View/WidgetListView/WidgetListView.swift
@@ -93,11 +93,11 @@ struct WidgetListView: View {
                     viewModel: viewModel,
                     onChannelAdded: { channel in
                         navigateToChannelId = channel.id
-                        if viewModel.channels.count > 1 {
-                            AnalyticsService.shared.logReviewRequested()
-                            DispatchQueue.main.async {
-                                requestReview()
-                            }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                            ReviewPromptService.shared.requestReviewIfAppropriate(
+                                channelCount: viewModel.channels.count,
+                                requestReview: { requestReview() }
+                            )
                         }
                     }
                 )


### PR DESCRIPTION
## Summary
- add a lightweight review prompt manager with per-session suppression, cooldown, and total-attempt limits
- trigger `requestReview()` after the first successful channel add instead of waiting for a second channel
- suppress automatic review prompts after a paywall is shown in the same session and stop auto-prompts after the user taps the manual Rate button

## Behavior
- review prompt can fire after a successful first channel add
- at most once per session
- blocked for the rest of the session if a paywall was shown
- max 3 total request attempts with a 30-day cooldown between attempts
- no future auto-prompts once the user taps Settings > Rate

## Notes
- this intentionally stays less conservative because many users only add one channel and may rarely reopen the app after widget setup

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arjun-dureja/subwidget/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
