### PR TITLE
Add widget tap upgrade prompt

### DIFF
--- a/SubscriberCount/SubWidgetIntentTimelineProvider.swift
+++ b/SubscriberCount/SubWidgetIntentTimelineProvider.swift
@@ -223,6 +223,10 @@ struct SubscriberCountEntryView: View {
         guard entry.channel != nil else { return false }
         guard !hasProAccess else { return false }
         guard !isPreview else { return false }
+        return isProOnlyWidgetKind
+    }
+
+    private var isProOnlyWidgetKind: Bool {
         switch widgetFamily {
         case .systemSmall:
             return entry.widgetType != .subscribers
@@ -239,7 +243,7 @@ struct SubscriberCountEntryView: View {
 
     private var deepLink: URL? {
         if !hasProAccess {
-            return WidgetDeepLink.paywall(source: isLocked ? "widget_locked" : "widget_free")
+            return WidgetDeepLink.paywall(source: isProOnlyWidgetKind ? "widget_locked" : "widget_free")
         }
 
         guard let baseUrl = entry.channel?.deeplinkUrl else { return nil }

--- a/SubscriberCount/SubWidgetIntentTimelineProvider.swift
+++ b/SubscriberCount/SubWidgetIntentTimelineProvider.swift
@@ -33,7 +33,13 @@ struct SimpleEntry: TimelineEntry {
 }
 
 private enum WidgetDeepLink {
-    static let paywall = URL(string: "subwidget://paywall")
+    static func paywall(source: String) -> URL? {
+        var components = URLComponents()
+        components.scheme = "subwidget"
+        components.host = "paywall"
+        components.queryItems = [URLQueryItem(name: "source", value: source)]
+        return components.url
+    }
 }
 
 struct SubWidgetIntentTimelineProvider: IntentTimelineProvider {
@@ -233,7 +239,7 @@ struct SubscriberCountEntryView: View {
 
     private var deepLink: URL? {
         if !hasProAccess {
-            return WidgetDeepLink.paywall
+            return WidgetDeepLink.paywall(source: isLocked ? "widget_locked" : "widget_free")
         }
 
         guard let baseUrl = entry.channel?.deeplinkUrl else { return nil }

--- a/SubscriberWidget/Localizable.xcstrings
+++ b/SubscriberWidget/Localizable.xcstrings
@@ -2297,6 +2297,82 @@
         }
       }
     },
+    "Close" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إغلاق"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schließen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "बंद करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutup"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閉じる"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жабу"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fechar"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "மூடு"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kapat"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
+          }
+        }
+      }
+    },
     "Colors" : {
       "localizations" : {
         "ar" : {
@@ -5503,6 +5579,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "玛瑙"
+          }
+        }
+      }
+    },
+    "Open in YouTube" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فتح في YouTube"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In YouTube öffnen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir en YouTube"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir dans YouTube"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube में खोलें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buka di YouTube"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTubeで開く"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube-та ашу"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir no YouTube"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube இல் திற"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube'da aç"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 YouTube 中打开"
           }
         }
       }
@@ -9455,6 +9607,158 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新频率"
+          }
+        }
+      }
+    },
+    "Upgrade now" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قم بالترقية الآن"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jetzt upgraden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mejorar ahora"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passer à niveau"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अभी अपग्रेड करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upgrade sekarang"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今すぐアップグレード"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қазір жаңартыңыз"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fazer upgrade agora"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "இப்போது மேம்படுத்து"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Şimdi yükselt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即升级"
+          }
+        }
+      }
+    },
+    "Upgrade to Pro to open your YouTube channel directly from the widget" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قم بالترقية إلى Pro لفتح قناتك على YouTube مباشرة من الأداة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upgrade auf Pro, um deinen YouTube-Kanal direkt aus dem Widget zu öffnen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualiza a Pro para abrir tu canal de YouTube directamente desde el widget"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passez à Pro pour ouvrir votre chaîne YouTube directement depuis le widget"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विजेट से सीधे अपना YouTube चैनल खोलने के लिए Pro में अपग्रेड करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upgrade ke Pro untuk membuka channel YouTube Anda langsung dari widget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットから直接 YouTube チャンネルを開くには Pro にアップグレード"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube арнаңызды виджеттен тікелей ашу үшін Pro нұсқасына жаңартыңыз"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faça upgrade para o Pro para abrir seu canal do YouTube diretamente pelo widget"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "விட்ஜெட்டிலிருந்தே உங்கள் YouTube சேனலை நேரடியாகத் திறக்க Pro-க்கு மேம்படுத்துங்கள்"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube kanalınızı doğrudan widget'tan açmak için Pro'ya yükseltin"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "升级到 Pro，即可直接从小组件打开你的 YouTube 频道"
           }
         }
       }

--- a/SubscriberWidget/SceneDelegate.swift
+++ b/SubscriberWidget/SceneDelegate.swift
@@ -37,8 +37,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     private func handleDeepLink(_ url: URL) {
         if url.host() == "paywall" {
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            let source = components?.queryItems?.first(where: { $0.name == "source" })?.value ?? "widget_free"
             UserDefaults.shared?.set(true, forKey: "pendingPaywallFromWidget")
-            NotificationCenter.default.post(name: .paywallRequested, object: nil)
+            UserDefaults.shared?.set(source, forKey: "pendingWidgetPaywallSource")
+            NotificationCenter.default.post(name: .paywallRequested, object: source)
             return
         }
 

--- a/SubscriberWidget/SceneDelegate.swift
+++ b/SubscriberWidget/SceneDelegate.swift
@@ -38,7 +38,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private func handleDeepLink(_ url: URL) {
         if url.host() == "paywall" {
             let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-            let source = components?.queryItems?.first(where: { $0.name == "source" })?.value ?? "widget_free"
+            let source = components?.queryItems?.first(where: { $0.name == "source" })?.value ?? "widget_legacy"
             UserDefaults.shared?.set(true, forKey: "pendingPaywallFromWidget")
             UserDefaults.shared?.set(source, forKey: "pendingWidgetPaywallSource")
             NotificationCenter.default.post(name: .paywallRequested, object: source)

--- a/SubscriberWidget/Services/AnalyticsService.swift
+++ b/SubscriberWidget/Services/AnalyticsService.swift
@@ -266,6 +266,12 @@ class AnalyticsService {
         ])
     }
 
+    func logWidgetUpgradeAlertShown(source: String) {
+        logEvent("widget_upgrade_alert.shown", properties: [
+            "source": source
+        ])
+    }
+
     func logOnboardingShown() {
         logEvent("onboarding.shown")
     }

--- a/SubscriberWidget/View/MainView.swift
+++ b/SubscriberWidget/View/MainView.swift
@@ -21,10 +21,13 @@ struct MainView: View {
     @State private var currentTab = 0
     @State private var confettiTrigger = 0
     @State private var showPaywall = false
+    @State private var showWidgetUpgradeAlert = false
     @State private var showOnboarding = false
     @State private var hasPreparedInitialPresentation = false
     @State private var onboardingAction: OnboardingAction = .none
+    @State private var widgetPaywallSource = "widget_free"
     @AppStorage("pendingPaywallFromWidget", store: .shared) private var pendingPaywallFromWidget: Bool = false
+    @AppStorage("pendingWidgetPaywallSource", store: .shared) private var pendingWidgetPaywallSource: String = "widget_free"
     @AppStorage("hasProAccess", store: .shared) private var hasProAccess: Bool = false
     @AppStorage("hasCompletedOnboarding", store: .shared) private var hasCompletedOnboarding: Bool = false
 
@@ -79,8 +82,9 @@ struct MainView: View {
             confettiTrigger += 1
             WidgetCenter.shared.reloadAllTimelines()
         }
-        .onReceive(NotificationCenter.default.publisher(for: .paywallRequested)) { _ in
-            handleWidgetPaywallRequest(source: "widget")
+        .onReceive(NotificationCenter.default.publisher(for: .paywallRequested)) { notification in
+            let source = notification.object as? String ?? "widget_free"
+            handleWidgetPaywallRequest(source: source)
         }
         .onChange(of: hasProAccess) { hasProAccess in
             guard hasProAccess else { return }
@@ -90,11 +94,20 @@ struct MainView: View {
         .onAppear {
             if pendingPaywallFromWidget {
                 pendingPaywallFromWidget = false
-                handleWidgetPaywallRequest(source: "widget_cold_start")
+                handleWidgetPaywallRequest(source: pendingWidgetPaywallSource)
             }
         }
         .task {
             await prepareInitialPresentation()
+        }
+        .alert("Open in YouTube", isPresented: $showWidgetUpgradeAlert) {
+            Button("Close", role: .cancel) {}
+            Button("Upgrade now") {
+                AnalyticsService.shared.logPaywallShown(source: widgetPaywallSource)
+                showPaywall = true
+            }
+        } message: {
+            Text("Upgrade to Pro to open your YouTube channel directly from the widget")
         }
         .confettiCannon(
             trigger: $confettiTrigger,
@@ -119,8 +132,15 @@ struct MainView: View {
         Task {
             await SubscriptionService().checkAccess()
             if !hasProAccess {
-                AnalyticsService.shared.logPaywallShown(source: source)
-                showPaywall = true
+                if source == "widget_locked" {
+                    AnalyticsService.shared.logPaywallShown(source: source)
+                    showPaywall = true
+                    return
+                }
+
+                widgetPaywallSource = source
+                AnalyticsService.shared.logWidgetUpgradeAlertShown(source: source)
+                showWidgetUpgradeAlert = true
             }
         }
     }

--- a/SubscriberWidget/View/MainView.swift
+++ b/SubscriberWidget/View/MainView.swift
@@ -27,7 +27,7 @@ struct MainView: View {
     @State private var onboardingAction: OnboardingAction = .none
     @State private var widgetPaywallSource = "widget_free"
     @AppStorage("pendingPaywallFromWidget", store: .shared) private var pendingPaywallFromWidget: Bool = false
-    @AppStorage("pendingWidgetPaywallSource", store: .shared) private var pendingWidgetPaywallSource: String = "widget_free"
+    @AppStorage("pendingWidgetPaywallSource", store: .shared) private var pendingWidgetPaywallSource: String = "widget_legacy"
     @AppStorage("hasProAccess", store: .shared) private var hasProAccess: Bool = false
     @AppStorage("hasCompletedOnboarding", store: .shared) private var hasCompletedOnboarding: Bool = false
 
@@ -83,7 +83,8 @@ struct MainView: View {
             WidgetCenter.shared.reloadAllTimelines()
         }
         .onReceive(NotificationCenter.default.publisher(for: .paywallRequested)) { notification in
-            let source = notification.object as? String ?? "widget_free"
+            let source = notification.object as? String ?? "widget_legacy"
+            clearPendingWidgetPaywallRequest()
             handleWidgetPaywallRequest(source: source)
         }
         .onChange(of: hasProAccess) { hasProAccess in
@@ -93,8 +94,9 @@ struct MainView: View {
         }
         .onAppear {
             if pendingPaywallFromWidget {
-                pendingPaywallFromWidget = false
-                handleWidgetPaywallRequest(source: pendingWidgetPaywallSource)
+                let source = pendingWidgetPaywallSource
+                clearPendingWidgetPaywallRequest()
+                handleWidgetPaywallRequest(source: source)
             }
         }
         .task {
@@ -132,7 +134,7 @@ struct MainView: View {
         Task {
             await SubscriptionService().checkAccess()
             if !hasProAccess {
-                if source == "widget_locked" {
+                if source == "widget_locked" || source == "widget_legacy" {
                     AnalyticsService.shared.logPaywallShown(source: source)
                     showPaywall = true
                     return
@@ -143,6 +145,11 @@ struct MainView: View {
                 showWidgetUpgradeAlert = true
             }
         }
+    }
+
+    private func clearPendingWidgetPaywallRequest() {
+        pendingPaywallFromWidget = false
+        pendingWidgetPaywallSource = "widget_legacy"
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- show a widget-specific upgrade alert before the paywall when free users tap free widgets
- keep locked Pro widgets opening the paywall immediately
- track widget tap source in analytics and add missing localized strings for the new alert copy

## Testing
- Not run (not requested)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arjun-dureja/subwidget/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
