### PR TITLE
Add shareable widget image editor

### DIFF
--- a/SubscriberCount/Views/MediumWidget.swift
+++ b/SubscriberCount/Views/MediumWidget.swift
@@ -16,6 +16,8 @@ private enum CountMode {
 
 struct MediumWidget: View {
     var entry: SimpleEntry?
+    var forceEntryImage: Bool = false
+    var exportMode: Bool = false
     @Environment(\.colorScheme) var colorScheme
 
     @AppStorage("showUpdateTime", store: .shared) var showUpdateTime: Bool = true
@@ -73,6 +75,7 @@ struct MediumWidget: View {
     }
 
     private var shouldShowRefreshButton: Bool {
+        guard !exportMode else { return false }
         guard hasProAccess else { return false }
         guard showWidgetRefreshButton else { return false }
         guard channel?.channelName != YouTubeChannel.preview.channelName else { return false }
@@ -84,7 +87,7 @@ struct MediumWidget: View {
             if let entry = entry,
                let channel = channel {
                 HStack {
-                    if Utils.isInWidget() || usesLocalPreviewImage {
+                    if forceEntryImage || Utils.isInWidget() || usesLocalPreviewImage {
                         Image(uiImage: entry.channelImage)
                             .resizable()
                             .widgetAccentedRenderingMode(.desaturated)
@@ -153,7 +156,7 @@ struct MediumWidget: View {
                             .font(widgetFont.font(size: 11))
                             .foregroundColor(accentColor)
                             .frame(maxHeight: .infinity, alignment: .bottom)
-                            .opacity(showUpdateTime ? 1 : 0)
+                            .opacity(showUpdateTime && !exportMode ? 1 : 0)
                     }
                 }
                 .minimumScaleFactor(0.3)

--- a/SubscriberCount/Views/SmallWidget.swift
+++ b/SubscriberCount/Views/SmallWidget.swift
@@ -11,6 +11,8 @@ import WidgetKit
 
 struct SmallWidget: View {
     var entry: SimpleEntry?
+    var forceEntryImage: Bool = false
+    var exportMode: Bool = false
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.showsWidgetContainerBackground) var showsWidgetContainerBackground
     @Environment(\.widgetRenderingMode) var widgetRenderingMode
@@ -65,6 +67,7 @@ struct SmallWidget: View {
     }
 
     private var shouldShowRefreshButton: Bool {
+        guard !exportMode else { return false }
         guard hasProAccess else { return false }
         guard showWidgetRefreshButton else { return false }
         guard channel?.channelName != YouTubeChannel.preview.channelName else { return false }
@@ -81,7 +84,7 @@ struct SmallWidget: View {
 
                 VStack(alignment: .leading) {
                     HStack {
-                        if Utils.isInWidget() || usesLocalPreviewImage {
+                        if forceEntryImage || Utils.isInWidget() || usesLocalPreviewImage {
                             Image(uiImage: entry.channelImage)
                                 .resizable()
                                 .widgetAccentedRenderingMode(.desaturated)
@@ -109,7 +112,7 @@ struct SmallWidget: View {
                             Text(lastUpdatedTime)
                                 .font(widgetFont.font(size: 10))
                                 .foregroundColor(accentColor)
-                                .opacity(showUpdateTime ? 1 : 0)
+                                .opacity(showUpdateTime && !exportMode ? 1 : 0)
                         }
                         .frame(maxHeight: .infinity, alignment: .top)
                     }

--- a/SubscriberWidget/Localizable.xcstrings
+++ b/SubscriberWidget/Localizable.xcstrings
@@ -2833,7 +2833,86 @@
       }
     },
     "Couldn't Share Widget" : {
-
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر مشاركة الأداة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget konnte nicht geteilt werden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't Share Widget"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo compartir el widget"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de partager le widget"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विजेट साझा नहीं किया जा सका"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget tidak dapat dibagikan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットを共有できませんでした"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджетті бөлісу мүмкін болмады"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível compartilhar o widget"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "விட்ஜெட்டை பகிர முடியவில்லை"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget paylaşılamadı"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法分享小组件"
+          }
+        }
+      }
     },
     "Deepsea" : {
       "localizations" : {
@@ -8853,6 +8932,88 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "免费开始"
+          }
+        }
+      }
+    },
+    "Something went wrong while generating the widget image." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حدث خطأ أثناء إنشاء صورة الأداة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beim Erstellen des Widget-Bildes ist ein Fehler aufgetreten."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something went wrong while generating the widget image."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algo salió mal al generar la imagen del widget."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une erreur s’est produite lors de la génération de l’image du widget."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विजेट छवि बनाते समय कुछ गलत हो गया।"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terjadi kesalahan saat membuat gambar widget."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェット画像の生成中に問題が発生しました。"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджет суретін жасау кезінде қате орын алды."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Algo deu errado ao gerar a imagem do widget."
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "விட்ஜெட் படத்தை உருவாக்கும் போது ஏதோ தவறு ஏற்பட்டது."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget görseli oluşturulurken bir sorun oluştu."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成小组件图片时出现问题。"
           }
         }
       }

--- a/SubscriberWidget/Localizable.xcstrings
+++ b/SubscriberWidget/Localizable.xcstrings
@@ -1454,6 +1454,82 @@
         }
       }
     },
+    "Border" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الحدود"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rahmen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borde"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bordure"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "बॉर्डर"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bingkai"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "枠線"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жиек"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borda"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "எல்லை"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kenarlık"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "边框"
+          }
+        }
+      }
+    },
     "by Arjun Dureja" : {
       "localizations" : {
         "ar" : {
@@ -2449,6 +2525,9 @@
         }
       }
     },
+    "Color" : {
+
+    },
     "Colors" : {
       "localizations" : {
         "ar" : {
@@ -2752,6 +2831,9 @@
           }
         }
       }
+    },
+    "Couldn't Share Widget" : {
+
     },
     "Deepsea" : {
       "localizations" : {
@@ -3893,6 +3975,82 @@
         }
       }
     },
+    "Glow" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التوهج"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leuchten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brillo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lueur"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ग्लो"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cahaya"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "グロー"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жарқыл"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brilho"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ஒளிர்வு"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parlama"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "光晕"
+          }
+        }
+      }
+    },
     "Harvest" : {
       "localizations" : {
         "ar" : {
@@ -4661,6 +4819,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "我有一个想要请求的功能想法。"
+          }
+        }
+      }
+    },
+    "Made with SubWidget" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم الإنشاء باستخدام SubWidget"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellt mit SubWidget"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hecho con SubWidget"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créé avec SubWidget"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget के साथ बनाया गया"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dibuat dengan SubWidget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget で作成"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget көмегімен жасалған"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feito com SubWidget"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget மூலம் உருவாக்கப்பட்டது"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SubWidget ile yapıldı"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 SubWidget 制作"
           }
         }
       }
@@ -8091,6 +8325,310 @@
         }
       }
     },
+    "Shadow" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الظل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schatten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sombra"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ombre"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "छाया"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bayangan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "影"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Көлеңке"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sombra"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "நிழல்"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gölge"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阴影"
+          }
+        }
+      }
+    },
+    "Share" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مشاركة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teilen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partager"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "शेयर करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共有"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бөлісу"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartilhar"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "பகிர்"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paylaş"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享"
+          }
+        }
+      }
+    },
+    "Share Image" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مشاركة الصورة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bild teilen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir imagen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partager l’image"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "छवि साझा करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan gambar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像を共有"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Суретті бөлісу"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartilhar imagem"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "படத்தை பகிர்"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Görseli paylaş"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享图片"
+          }
+        }
+      }
+    },
+    "Share Widget" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مشاركة الأداة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget teilen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir widget"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partager le widget"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विजेट साझा करें"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bagikan widget"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウィジェットを共有"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виджетті бөлісу"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartilhar widget"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "விட்ஜெட்டை பகிர்"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widget'ı paylaş"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分享小组件"
+          }
+        }
+      }
+    },
     "Show Update Time" : {
       "localizations" : {
         "ar" : {
@@ -9075,6 +9613,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "小组件是空白的。"
+          }
+        }
+      }
+    },
+    "Thickness" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "السماكة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dicke"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grosor"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épaisseur"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मोटाई"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ketebalan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "太さ"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Қалыңдығы"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espessura"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "தடிமன்"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kalınlık"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粗细"
           }
         }
       }
@@ -11051,6 +11665,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "YouTube 频道统计数据一目了然"
+          }
+        }
+      }
+    },
+    "Zoom" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التكبير"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ज़ूम"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ズーム"
+          }
+        },
+        "kk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Үлкейту"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "ta" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "பெரிதாக்கு"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yakınlaştırma"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缩放"
           }
         }
       }

--- a/SubscriberWidget/Services/AnalyticsService.swift
+++ b/SubscriberWidget/Services/AnalyticsService.swift
@@ -173,6 +173,34 @@ class AnalyticsService {
         ])
     }
 
+    func logWidgetShareTapped(page: String, channelName: String) {
+        logEvent("widget_share.tapped", properties: [
+            "page": page,
+            "channelName": channelName
+        ])
+    }
+
+    func logWidgetShareSucceeded(page: String, channelName: String) {
+        logEvent("widget_share.succeeded", properties: [
+            "page": page,
+            "channelName": channelName
+        ])
+    }
+
+    func logWidgetShareFailed(page: String, channelName: String, message: String) {
+        logEvent("widget_share.failed", properties: [
+            "page": page,
+            "channelName": channelName,
+            "message": message
+        ])
+    }
+
+    func logWidgetShareBackgroundSelected(name: String) {
+        logEvent("widget_share.background_selected", properties: [
+            "name": name
+        ])
+    }
+
     func logWidgetChannelFetchFailed(_ message: String) {
         logEvent("widget.channel_fetch_failed", properties: [
             "message": message

--- a/SubscriberWidget/View/CustomizeWidgetView/CustomizeWidgetView.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/CustomizeWidgetView.swift
@@ -15,10 +15,10 @@ struct CustomizeWidgetView: View {
     @State var channel: YouTubeChannel
 
     @Environment(\.colorScheme) var colorScheme
-    @Environment(\.openURL) var openURL
     @AppStorage("hasProAccess", store: .shared) private var hasProAccess: Bool = false
 
-    @State private var bgColor: CGColor?
+    @State private var currentPage: WidgetPreviewPage = .subscribersSmall
+    @State private var showShareEditor = false
     @State private var showPaywall = false
 
     let columns = [
@@ -31,7 +31,7 @@ struct CustomizeWidgetView: View {
                 Spacer()
                     .frame(height: 8)
 
-                WidgetPreview(channel: $channel)
+                WidgetPreview(channel: $channel, currentPage: $currentPage)
                     .frame(maxWidth: 650)
 
                 Form {
@@ -95,6 +95,23 @@ struct CustomizeWidgetView: View {
         .background(colorScheme == .light ? Color(UIColor.systemGray6) : .black)
         .ignoresSafeArea(.keyboard, edges: .all)
         .paywallSheet(isPresented: $showPaywall)
+        .sheet(isPresented: $showShareEditor) {
+            ShareEditorView(
+                channel: channel,
+                page: currentPage,
+                hasProAccess: hasProAccess,
+                colorScheme: colorScheme
+            )
+            .presentationDetents([.large])
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: openShareEditor) {
+                    Image(systemName: "square.and.arrow.up")
+                }
+                .accessibilityLabel("Share Widget")
+            }
+        }
         .onAppear {
             AnalyticsService.shared.logCustomizeWidgetScreenOpened(
                 channel.channelName,
@@ -164,6 +181,16 @@ struct CustomizeWidgetView: View {
             enabled: channel.milestoneEnabled
         )
         WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    func openShareEditor() {
+        guard hasProAccess || !currentPage.isProOnly else {
+            AnalyticsService.shared.logPaywallShown(source: "share_locked_widget")
+            showPaywall = true
+            return
+        }
+
+        showShareEditor = true
     }
 }
 

--- a/SubscriberWidget/View/CustomizeWidgetView/ShareEditorView.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/ShareEditorView.swift
@@ -180,7 +180,6 @@ struct ShareEditorView: View {
                 VStack(spacing: 14) {
                     HStack(spacing: 24) {
                         Text("Thickness")
-                            .font(.subheadline.bold())
 
                         Slider(value: $configuration.borderWidth, in: 1...8)
                             .tint(.youtubeRed)

--- a/SubscriberWidget/View/CustomizeWidgetView/ShareEditorView.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/ShareEditorView.swift
@@ -85,12 +85,12 @@ struct ShareEditorView: View {
         .onChange(of: configuration.backgroundStyle) { style in
             AnalyticsService.shared.logWidgetShareBackgroundSelected(name: style.rawValue)
         }
-        .alert("Couldn't Share Widget", isPresented: errorBinding) {
+        .alert(String(localized: "Couldn't Share Widget"), isPresented: errorBinding) {
             Button("OK", role: .cancel) {
                 errorMessage = nil
             }
         } message: {
-            Text(errorMessage ?? "Something went wrong while generating the widget image.")
+            Text(errorMessage ?? String(localized: "Something went wrong while generating the widget image."))
         }
     }
 

--- a/SubscriberWidget/View/CustomizeWidgetView/ShareEditorView.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/ShareEditorView.swift
@@ -1,0 +1,449 @@
+//
+//  ShareEditorView.swift
+//  SubscriberWidget
+//
+//  Created by Codex on 2025-02-14.
+//
+
+import SwiftUI
+
+struct ShareEditorView: View {
+    let channel: YouTubeChannel
+    let page: WidgetPreviewPage
+    let hasProAccess: Bool
+    let colorScheme: ColorScheme
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var configuration: ShareCardConfiguration
+    @State private var isSharing = false
+    @State private var previewImage: UIImage?
+    @State private var shareItems: [Any] = []
+    @State private var showShareSheet = false
+    @State private var errorMessage: String?
+    @State private var previewRenderTask: Task<Void, Never>?
+
+    init(channel: YouTubeChannel, page: WidgetPreviewPage, hasProAccess: Bool, colorScheme: ColorScheme) {
+        self.channel = channel
+        self.page = page
+        self.hasProAccess = hasProAccess
+        self.colorScheme = colorScheme
+        _configuration = State(initialValue: ShareCardConfiguration())
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                VStack(spacing: 14) {
+                    previewSection
+                    ZStack(alignment: .bottom) {
+                        ScrollView {
+                            controlsSection
+                                .padding(.bottom, 28)
+                        }
+
+                        LinearGradient(
+                            colors: [
+                                Color(UIColor.systemGroupedBackground).opacity(0.0),
+                                Color(UIColor.systemGroupedBackground).opacity(0.95)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 38)
+                        .allowsHitTesting(false)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+
+                Spacer(minLength: 0)
+                shareButtonBar
+            }
+            .background(Color(UIColor.systemGroupedBackground))
+            .navigationBarTitle("Share", displayMode: .inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Close") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $showShareSheet) {
+            ShareSheet(activityItems: shareItems)
+        }
+        .onAppear {
+            schedulePreviewRender()
+        }
+        .onDisappear {
+            previewRenderTask?.cancel()
+        }
+        .onChange(of: configuration) { _ in
+            schedulePreviewRender()
+        }
+        .onChange(of: configuration.backgroundStyle) { style in
+            AnalyticsService.shared.logWidgetShareBackgroundSelected(name: style.rawValue)
+        }
+        .alert("Couldn't Share Widget", isPresented: errorBinding) {
+            Button("OK", role: .cancel) {
+                errorMessage = nil
+            }
+        } message: {
+            Text(errorMessage ?? "Something went wrong while generating the widget image.")
+        }
+    }
+
+    private var previewSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Preview")
+                .font(.headline)
+                .padding(.horizontal, 2)
+
+            ZStack {
+                if let previewImage {
+                    GeometryReader { geometry in
+                        let side = min(geometry.size.width, geometry.size.height) - 18
+
+                        Image(uiImage: previewImage)
+                            .resizable()
+                            .interpolation(.high)
+                            .aspectRatio(1, contentMode: .fit)
+                            .frame(width: side, height: side)
+                            .clipShape(RoundedRectangle(cornerRadius: 22))
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+                } else {
+                    ProgressView()
+                }
+            }
+            .frame(height: 270)
+            .background(
+                RoundedRectangle(cornerRadius: 28)
+                    .fill(Color(UIColor.secondarySystemGroupedBackground))
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 28)
+                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            }
+        }
+    }
+
+    private var controlsSection: some View {
+        VStack(spacing: 12) {
+            ShareControlCard(title: "Background") {
+                VStack(alignment: .leading, spacing: 14) {
+                    BackgroundSwatchPicker(
+                        options: ShareBackgroundStyle.allCases,
+                        selection: $configuration.backgroundStyle,
+                        solidBackgroundColor: configuration.solidBackgroundColor
+                    )
+
+                    if configuration.backgroundStyle == .solid {
+                        ColorPicker(
+                            "Color",
+                            selection: Binding(
+                                get: { configuration.solidBackgroundColor },
+                                set: { configuration.solidBackgroundHex = UIColor($0).hexStringFromColor() }
+                            ),
+                            supportsOpacity: false
+                        )
+                    }
+                }
+            }
+
+            ShareControlCard {
+                HStack(spacing: 14) {
+                    Text("Zoom")
+                        .font(.subheadline.bold())
+                        .frame(width: 70, alignment: .leading)
+
+                    Slider(value: $configuration.zoom, in: 0.85...1.2)
+                        .tint(.youtubeRed)
+                }
+            }
+
+            ShareControlCard {
+                HStack(spacing: 14) {
+                    Text("Shadow")
+                        .font(.subheadline.bold())
+                        .frame(width: 70, alignment: .leading)
+
+                    Slider(value: $configuration.shadowStrength, in: 0...1)
+                        .tint(.youtubeRed)
+                }
+            }
+
+            ShareToggleCard(title: "Glow", isOn: $configuration.showsGlow)
+
+            ShareToggleCard(title: "Border", isOn: $configuration.showsBorder) {
+                VStack(spacing: 14) {
+                    HStack(spacing: 24) {
+                        Text("Thickness")
+                            .font(.subheadline.bold())
+
+                        Slider(value: $configuration.borderWidth, in: 1...8)
+                            .tint(.youtubeRed)
+                    }
+
+                    ColorPicker(
+                        "Color",
+                        selection: Binding(
+                            get: { configuration.borderColor },
+                            set: { configuration.borderHex = UIColor($0).hexStringFromColor() }
+                        ),
+                        supportsOpacity: false
+                    )
+                }
+            }
+        }
+    }
+
+    private var shareButtonBar: some View {
+        VStack(spacing: 0) {
+            Button(action: share) {
+                HStack {
+                    Spacer()
+                    if isSharing {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Label("Share Image", systemImage: "square.and.arrow.up")
+                            .font(.headline)
+                    }
+                    Spacer()
+                }
+                .padding(.vertical, 18)
+                .background(Color.youtubeRed)
+                .foregroundStyle(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+            }
+            .disabled(isSharing)
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 16)
+        }
+        .background(
+            LinearGradient(
+                colors: [
+                    Color(UIColor.systemGroupedBackground).opacity(0.0),
+                    Color(UIColor.systemGroupedBackground),
+                    Color(UIColor.systemGroupedBackground)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )
+    }
+
+    private func share() {
+        isSharing = true
+        AnalyticsService.shared.logWidgetShareTapped(
+            page: page.analyticsName,
+            channelName: channel.channelName
+        )
+
+        Task {
+            do {
+                let url = try await WidgetShareRenderer().render(
+                    channel: channel,
+                    page: page,
+                    hasProAccess: hasProAccess,
+                    colorScheme: colorScheme,
+                    configuration: configuration
+                )
+
+                await MainActor.run {
+                    shareItems = [url]
+                    showShareSheet = true
+                    isSharing = false
+                    AnalyticsService.shared.logWidgetShareSucceeded(
+                        page: page.analyticsName,
+                        channelName: channel.channelName
+                    )
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    isSharing = false
+                    AnalyticsService.shared.logWidgetShareFailed(
+                        page: page.analyticsName,
+                        channelName: channel.channelName,
+                        message: error.localizedDescription
+                    )
+                }
+            }
+        }
+    }
+
+    private func renderPreview() async {
+        do {
+            let image = try await WidgetShareRenderer().renderImage(
+                channel: channel,
+                page: page,
+                hasProAccess: hasProAccess,
+                colorScheme: colorScheme,
+                configuration: configuration
+            )
+
+            await MainActor.run {
+                previewImage = image
+            }
+        } catch {
+            await MainActor.run {
+                previewImage = nil
+            }
+        }
+    }
+
+    private func schedulePreviewRender() {
+        previewRenderTask?.cancel()
+        previewRenderTask = Task {
+            try? await Task.sleep(nanoseconds: 120_000_000)
+            guard !Task.isCancelled else { return }
+            await renderPreview()
+        }
+    }
+}
+
+private struct ShareControlCard<Content: View>: View {
+    let title: String?
+    let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    init(@ViewBuilder content: () -> Content) {
+        self.title = nil
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let title {
+                Text(title)
+                    .font(.subheadline.bold())
+            }
+
+            content
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color(UIColor.secondarySystemGroupedBackground))
+        )
+    }
+}
+
+private struct ShareToggleCard<Content: View>: View {
+    let title: String
+    @Binding var isOn: Bool
+    let content: Content?
+
+    init(title: String, isOn: Binding<Bool>) where Content == EmptyView {
+        self.title = title
+        self._isOn = isOn
+        self.content = nil
+    }
+
+    init(title: String, isOn: Binding<Bool>, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self._isOn = isOn
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(title)
+                    .font(.subheadline.bold())
+                Spacer()
+                Toggle("", isOn: $isOn)
+                    .labelsHidden()
+                    .tint(.youtubeRed)
+            }
+
+            if isOn, let content {
+                content
+                    .padding(.top, 2)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color(UIColor.secondarySystemGroupedBackground))
+        )
+    }
+}
+
+private struct BackgroundSwatchPicker: View {
+    let options: [ShareBackgroundStyle]
+    @Binding var selection: ShareBackgroundStyle
+    let solidBackgroundColor: Color
+
+    var body: some View {
+        let columns = [
+            GridItem(.adaptive(minimum: 48, maximum: 56), spacing: 10)
+        ]
+
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(options) { option in
+                Button {
+                    selection = option
+                } label: {
+                    ZStack(alignment: .topTrailing) {
+                        RoundedRectangle(cornerRadius: 18)
+                            .fill(
+                                option.isSolid
+                                    ? AnyShapeStyle(solidBackgroundColor)
+                                    : AnyShapeStyle(
+                                        LinearGradient(
+                                            colors: option.colors,
+                                            startPoint: .topLeading,
+                                            endPoint: .bottomTrailing
+                                        )
+                                    )
+                            )
+                            .overlay {
+                                Circle()
+                                    .fill(option.glowColor.opacity(option.isSolid ? 0.18 : 0.28))
+                                    .frame(width: 36, height: 36)
+                                    .blur(radius: option.isSolid ? 20 : 28)
+                                    .offset(x: -8, y: 10)
+                            }
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 18)
+                                    .stroke(
+                                        selection == option ? Color.white.opacity(0.9) : Color.white.opacity(0.08),
+                                        lineWidth: selection == option ? 2.5 : 1
+                                    )
+                            }
+                            .frame(height: 48)
+
+                        if selection == option {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundStyle(.white)
+                                .frame(width: 22, height: 22)
+                                .background(.black.opacity(0.24))
+                                .clipShape(Circle())
+                                .padding(6)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}

--- a/SubscriberWidget/View/CustomizeWidgetView/ShareEditorView.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/ShareEditorView.swift
@@ -293,11 +293,15 @@ struct ShareEditorView: View {
                 configuration: configuration
             )
 
+            guard !Task.isCancelled else { return }
             await MainActor.run {
+                guard !Task.isCancelled else { return }
                 previewImage = image
             }
         } catch {
+            guard !Task.isCancelled else { return }
             await MainActor.run {
+                guard !Task.isCancelled else { return }
                 previewImage = nil
             }
         }

--- a/SubscriberWidget/View/CustomizeWidgetView/ShareSheet.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/ShareSheet.swift
@@ -1,0 +1,21 @@
+//
+//  ShareSheet.swift
+//  SubscriberWidget
+//
+//  Created by Codex on 2025-02-14.
+//
+
+import SwiftUI
+import UIKit
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+    }
+}
+

--- a/SubscriberWidget/View/CustomizeWidgetView/ShareableWidgetCard.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/ShareableWidgetCard.swift
@@ -117,6 +117,8 @@ extension ShareCardConfiguration: Equatable {
 struct ShareableWidgetCard: View {
     static let canvasSize = CGSize(width: 1_200, height: 1_200)
 
+    @Environment(\.colorScheme) private var colorScheme
+
     let channel: YouTubeChannel
     let page: WidgetPreviewPage
     let channelImage: UIImage?
@@ -142,7 +144,7 @@ struct ShareableWidgetCard: View {
         if let bgColor = channel.bgColor {
             return Color(bgColor)
         }
-        return .black
+        return colorScheme == .dark ? .black : .white
     }
 
     private var backgroundColors: [Color] {

--- a/SubscriberWidget/View/CustomizeWidgetView/ShareableWidgetCard.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/ShareableWidgetCard.swift
@@ -1,0 +1,242 @@
+//
+//  ShareableWidgetCard.swift
+//  SubscriberWidget
+//
+//  Created by Codex on 2025-02-14.
+//
+
+import SwiftUI
+import UIKit
+
+enum ShareBackgroundStyle: String, CaseIterable, Identifiable {
+    case ember
+    case ocean
+    case violet
+    case aurora
+    case rose
+    case sunrise
+    case citrus
+    case blush
+    case lagoon
+    case solid
+
+    var id: String { rawValue }
+
+    var colors: [Color] {
+        switch self {
+        case .ember:
+            return [Color(hex: "140D0D"), Color(hex: "3A1515"), Color(hex: "0B0B0E")]
+        case .ocean:
+            return [Color(hex: "0A1722"), Color(hex: "153E62"), Color(hex: "0B0D11")]
+        case .violet:
+            return [Color(hex: "171225"), Color(hex: "3F2A68"), Color(hex: "0E0D17")]
+        case .aurora:
+            return [Color(hex: "071A19"), Color(hex: "0E5B57"), Color(hex: "0A1020")]
+        case .rose:
+            return [Color(hex: "21101B"), Color(hex: "7C284F"), Color(hex: "120D12")]
+        case .sunrise:
+            return [Color(hex: "FFF1D6"), Color(hex: "FDBA74"), Color(hex: "FB7185")]
+        case .citrus:
+            return [Color(hex: "FEF3C7"), Color(hex: "FDE047"), Color(hex: "F59E0B")]
+        case .blush:
+            return [Color(hex: "FCE7F3"), Color(hex: "F9A8D4"), Color(hex: "C084FC")]
+        case .lagoon:
+            return [Color(hex: "D1FAE5"), Color(hex: "67E8F9"), Color(hex: "3B82F6")]
+        case .solid:
+            return [.black, .black, .black]
+        }
+    }
+
+    var glowColor: Color {
+        switch self {
+        case .ember:
+            return .youtubeRed
+        case .ocean:
+            return Color(hex: "38BDF8")
+        case .violet:
+            return Color(hex: "A78BFA")
+        case .aurora:
+            return Color(hex: "2DD4BF")
+        case .rose:
+            return Color(hex: "FB7185")
+        case .sunrise:
+            return Color(hex: "FB7185")
+        case .citrus:
+            return Color(hex: "F59E0B")
+        case .blush:
+            return Color(hex: "E879F9")
+        case .lagoon:
+            return Color(hex: "22D3EE")
+        case .solid:
+            return .white
+        }
+    }
+
+    var isSolid: Bool {
+        self == .solid
+    }
+
+}
+
+struct ShareCardConfiguration {
+    var backgroundStyle: ShareBackgroundStyle
+    var zoom: Double = 1.0
+    var showsGlow: Bool = true
+    var shadowStrength: Double = 0.75
+    var showsBorder: Bool = false
+    var borderWidth: Double = 2.5
+    var solidBackgroundHex: String = "#0B0B0D"
+    var borderHex: String = "#FFFFFF"
+
+    init() {
+        self.backgroundStyle = .ember
+    }
+
+    var solidBackgroundColor: Color {
+        Color(hex: solidBackgroundHex)
+    }
+
+    var borderColor: Color {
+        Color(hex: borderHex)
+    }
+}
+
+extension ShareCardConfiguration: Equatable {
+    static func == (lhs: ShareCardConfiguration, rhs: ShareCardConfiguration) -> Bool {
+        lhs.backgroundStyle == rhs.backgroundStyle &&
+        lhs.zoom == rhs.zoom &&
+        lhs.showsGlow == rhs.showsGlow &&
+        lhs.shadowStrength == rhs.shadowStrength &&
+        lhs.showsBorder == rhs.showsBorder &&
+        lhs.borderWidth == rhs.borderWidth &&
+        lhs.solidBackgroundHex == rhs.solidBackgroundHex &&
+        lhs.borderHex == rhs.borderHex
+    }
+}
+
+struct ShareableWidgetCard: View {
+    static let canvasSize = CGSize(width: 1_200, height: 1_200)
+
+    let channel: YouTubeChannel
+    let page: WidgetPreviewPage
+    let channelImage: UIImage?
+    let hasProAccess: Bool
+    let configuration: ShareCardConfiguration
+
+    private var baseWidgetScale: CGFloat {
+        let baseScale: CGFloat
+        switch page.size {
+        case .small:
+            baseScale = 4.35
+        case .medium:
+            baseScale = 2.9
+        }
+        return baseScale * configuration.zoom
+    }
+
+    private var widgetOffsetY: CGFloat {
+        page.size == .small ? -18 : -8
+    }
+
+    private var widgetBackgroundColor: Color {
+        if let bgColor = channel.bgColor {
+            return Color(bgColor)
+        }
+        return .black
+    }
+
+    private var backgroundColors: [Color] {
+        configuration.backgroundStyle.isSolid
+            ? Array(repeating: configuration.solidBackgroundColor, count: 3)
+            : configuration.backgroundStyle.colors
+    }
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: backgroundColors,
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            if configuration.showsGlow {
+                Circle()
+                    .fill(configuration.backgroundStyle.glowColor.opacity(configuration.backgroundStyle.isSolid ? 0.18 : 0.30))
+                    .frame(width: Self.canvasSize.width * 0.54, height: Self.canvasSize.width * 0.54)
+                    .blur(radius: configuration.backgroundStyle.isSolid ? 150 : 220)
+                    .offset(x: -Self.canvasSize.width * 0.17, y: -Self.canvasSize.height * 0.16)
+
+                Circle()
+                    .fill(
+                        (configuration.backgroundStyle.isSolid ? configuration.solidBackgroundColor : .white)
+                            .opacity(configuration.backgroundStyle.isSolid ? 0.08 : 0.16)
+                    )
+                    .frame(width: Self.canvasSize.width * 0.40, height: Self.canvasSize.width * 0.40)
+                    .blur(radius: configuration.backgroundStyle.isSolid ? 120 : 190)
+                    .offset(x: Self.canvasSize.width * 0.18, y: Self.canvasSize.height * 0.19)
+
+                Circle()
+                    .fill(configuration.backgroundStyle.glowColor.opacity(configuration.backgroundStyle.isSolid ? 0.08 : 0.05))
+                    .frame(width: Self.canvasSize.width * 0.78, height: Self.canvasSize.width * 0.78)
+                    .blur(radius: configuration.backgroundStyle.isSolid ? 140 : 120)
+                    .offset(x: 0, y: Self.canvasSize.height * 0.06)
+            }
+
+            RoundedRectangle(cornerRadius: 25)
+                .fill(widgetBackgroundColor)
+                .frame(width: page.size.width, height: 155)
+                .scaleEffect(baseWidgetScale)
+                .shadow(
+                    color: .black.opacity(0.24 + configuration.shadowStrength * 0.34),
+                    radius: 22 + configuration.shadowStrength * 50,
+                    y: 16 + configuration.shadowStrength * 28
+                )
+                .offset(y: widgetOffsetY)
+
+            ShareableWidgetPreview(
+                channel: channel,
+                page: page,
+                channelImage: channelImage,
+                hasProAccess: hasProAccess,
+                exportMode: true,
+                onUpgrade: nil
+            )
+            .overlay {
+                if configuration.showsBorder {
+                    RoundedRectangle(cornerRadius: 25)
+                        .stroke(configuration.borderColor.opacity(0.9), lineWidth: configuration.borderWidth)
+                        .frame(width: page.size.width, height: 155)
+                }
+            }
+            .scaleEffect(baseWidgetScale)
+            .offset(y: widgetOffsetY)
+
+            VStack {
+                Spacer()
+
+                HStack {
+                    Spacer()
+
+                    HStack(spacing: 12) {
+                        AppIcon()
+                            .cornerRadius(12)
+                            .opacity(0.75)
+                            .frame(width: 36, height: 36)
+
+                        Text("Made with SubWidget")
+                            .font(.system(size: 24, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.white.opacity(0.75))
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 14)
+                    .background(.black.opacity(0.14))
+                    .clipShape(RoundedRectangle(cornerRadius: 18))
+                }
+            }
+            .padding(.trailing, 42)
+            .padding(.bottom, 38)
+        }
+        .frame(width: Self.canvasSize.width, height: Self.canvasSize.height)
+        .clipped()
+    }
+}

--- a/SubscriberWidget/View/CustomizeWidgetView/ShareableWidgetPreview.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/ShareableWidgetPreview.swift
@@ -80,7 +80,7 @@ struct ShareableWidgetPreview: View {
     var body: some View {
         LockedPreview(size: page.size, isLocked: isLocked, onUpgrade: onUpgrade ?? {}) {
             widgetView
-                .widgetBackground(bgColor: channel.bgColor, size: page.size)
+                .widgetBackground(bgColor: channel.bgColor, size: page.size, showsShadow: !exportMode)
         }
     }
 
@@ -88,9 +88,9 @@ struct ShareableWidgetPreview: View {
     private var widgetView: some View {
         switch page.size {
         case .small:
-            SmallWidget(entry: entry, forceEntryImage: channelImage != nil, exportMode: exportMode)
+            SmallWidget(entry: entry, forceEntryImage: exportMode || channelImage != nil, exportMode: exportMode)
         case .medium:
-            MediumWidget(entry: entry, forceEntryImage: channelImage != nil, exportMode: exportMode)
+            MediumWidget(entry: entry, forceEntryImage: exportMode || channelImage != nil, exportMode: exportMode)
         }
     }
 }

--- a/SubscriberWidget/View/CustomizeWidgetView/ShareableWidgetPreview.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/ShareableWidgetPreview.swift
@@ -1,0 +1,96 @@
+//
+//  ShareableWidgetPreview.swift
+//  SubscriberWidget
+//
+//  Created by Codex on 2025-02-14.
+//
+
+import SwiftUI
+import UIKit
+
+enum WidgetPreviewPage: Int, CaseIterable, Identifiable {
+    case subscribersSmall
+    case subscribersMedium
+    case viewsSmall
+    case viewsMedium
+    case combinedMedium
+
+    var id: Int { rawValue }
+
+    var widgetType: WidgetType {
+        switch self {
+        case .subscribersSmall, .subscribersMedium:
+            return .subscribers
+        case .viewsSmall, .viewsMedium:
+            return .views
+        case .combinedMedium:
+            return .combined
+        }
+    }
+
+    var size: WidgetSize {
+        switch self {
+        case .subscribersSmall, .viewsSmall:
+            return .small
+        case .subscribersMedium, .viewsMedium, .combinedMedium:
+            return .medium
+        }
+    }
+
+    var analyticsName: String {
+        switch self {
+        case .subscribersSmall:
+            return "subscribers_small"
+        case .subscribersMedium:
+            return "subscribers_medium"
+        case .viewsSmall:
+            return "views_small"
+        case .viewsMedium:
+            return "views_medium"
+        case .combinedMedium:
+            return "combined_medium"
+        }
+    }
+
+    var isProOnly: Bool {
+        self != .subscribersSmall
+    }
+}
+
+struct ShareableWidgetPreview: View {
+    let channel: YouTubeChannel
+    let page: WidgetPreviewPage
+    let channelImage: UIImage?
+    let hasProAccess: Bool
+    var exportMode: Bool = false
+    let onUpgrade: (() -> Void)?
+
+    private var entry: SimpleEntry {
+        SimpleEntry(
+            channel: channel,
+            channelImage: channelImage ?? UIImage(systemName: "person.circle")!,
+            widgetType: page.widgetType
+        )
+    }
+
+    private var isLocked: Bool {
+        page.isProOnly && !hasProAccess
+    }
+
+    var body: some View {
+        LockedPreview(size: page.size, isLocked: isLocked, onUpgrade: onUpgrade ?? {}) {
+            widgetView
+                .widgetBackground(bgColor: channel.bgColor, size: page.size)
+        }
+    }
+
+    @ViewBuilder
+    private var widgetView: some View {
+        switch page.size {
+        case .small:
+            SmallWidget(entry: entry, forceEntryImage: channelImage != nil, exportMode: exportMode)
+        case .medium:
+            MediumWidget(entry: entry, forceEntryImage: channelImage != nil, exportMode: exportMode)
+        }
+    }
+}

--- a/SubscriberWidget/View/CustomizeWidgetView/WidgetBackground.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/WidgetBackground.swift
@@ -25,13 +25,17 @@ struct WidgetBackgroundModifier: ViewModifier {
 
     var bgColor: UIColor?
     var size: WidgetSize
+    var showsShadow: Bool
 
     func body(content: Content) -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: 25)
                 .frame(width: size.width, height: 155)
                 .foregroundColor(Color((bgColor ?? (colorScheme == .dark ? UIColor.black : UIColor.white))))
-                .shadow(color: colorScheme == .dark ? .white.opacity(0.20) : .black.opacity(0.33), radius: 8)
+                .shadow(
+                    color: colorScheme == .dark ? .white.opacity(0.20) : .black.opacity(0.33),
+                    radius: showsShadow ? 8 : 0
+                )
 
             content
                 .padding()
@@ -42,7 +46,7 @@ struct WidgetBackgroundModifier: ViewModifier {
 }
 
 extension View {
-    func widgetBackground(bgColor: UIColor?, size: WidgetSize) -> some View {
-        self.modifier(WidgetBackgroundModifier(bgColor: bgColor, size: size))
+    func widgetBackground(bgColor: UIColor?, size: WidgetSize, showsShadow: Bool = true) -> some View {
+        self.modifier(WidgetBackgroundModifier(bgColor: bgColor, size: size, showsShadow: showsShadow))
     }
 }

--- a/SubscriberWidget/View/CustomizeWidgetView/WidgetPreview.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/WidgetPreview.swift
@@ -13,7 +13,7 @@ struct WidgetPreview: View {
     @AppStorage("hasProAccess", store: .shared) private var hasProAccess: Bool = false
 
     @Binding var channel: YouTubeChannel
-    @State private var currentPage = 0
+    @Binding var currentPage: WidgetPreviewPage
     @State private var showPaywall = false
 
     var body: some View {
@@ -34,36 +34,50 @@ struct WidgetPreview: View {
             .padding(.top, 7)
 
             TabView(selection: $currentPage) {
-                let subCountEntry = SimpleEntry(channel: channel, widgetType: .subscribers)
-                SmallWidget(entry: subCountEntry)
-                    .widgetBackground(bgColor: channel.bgColor, size: .small)
-                    .tag(0)
+                ShareableWidgetPreview(
+                    channel: channel,
+                    page: .subscribersSmall,
+                    channelImage: nil,
+                    hasProAccess: hasProAccess,
+                    onUpgrade: handleUpgradeTapped
+                )
+                .tag(WidgetPreviewPage.subscribersSmall)
 
-                LockedPreview(size: .medium, isLocked: !hasProAccess, onUpgrade: handleUpgradeTapped) {
-                    MediumWidget(entry: subCountEntry)
-                        .widgetBackground(bgColor: channel.bgColor, size: .medium)
-                }
-                .tag(1)
+                ShareableWidgetPreview(
+                    channel: channel,
+                    page: .subscribersMedium,
+                    channelImage: nil,
+                    hasProAccess: hasProAccess,
+                    onUpgrade: handleUpgradeTapped
+                )
+                .tag(WidgetPreviewPage.subscribersMedium)
 
-                let viewCountEntry = SimpleEntry(channel: channel, widgetType: .views)
-                LockedPreview(size: .small, isLocked: !hasProAccess, onUpgrade: handleUpgradeTapped) {
-                    SmallWidget(entry: viewCountEntry)
-                        .widgetBackground(bgColor: channel.bgColor, size: .small)
-                }
-                .tag(2)
+                ShareableWidgetPreview(
+                    channel: channel,
+                    page: .viewsSmall,
+                    channelImage: nil,
+                    hasProAccess: hasProAccess,
+                    onUpgrade: handleUpgradeTapped
+                )
+                .tag(WidgetPreviewPage.viewsSmall)
 
-                LockedPreview(size: .medium, isLocked: !hasProAccess, onUpgrade: handleUpgradeTapped) {
-                    MediumWidget(entry: viewCountEntry)
-                        .widgetBackground(bgColor: channel.bgColor, size: .medium)
-                }
-                .tag(3)
+                ShareableWidgetPreview(
+                    channel: channel,
+                    page: .viewsMedium,
+                    channelImage: nil,
+                    hasProAccess: hasProAccess,
+                    onUpgrade: handleUpgradeTapped
+                )
+                .tag(WidgetPreviewPage.viewsMedium)
 
-                let combinedEntry = SimpleEntry(channel: channel, widgetType: .combined)
-                LockedPreview(size: .medium, isLocked: !hasProAccess, onUpgrade: handleUpgradeTapped) {
-                    MediumWidget(entry: combinedEntry)
-                        .widgetBackground(bgColor: channel.bgColor, size: .medium)
-                }
-                .tag(4)
+                ShareableWidgetPreview(
+                    channel: channel,
+                    page: .combinedMedium,
+                    channelImage: nil,
+                    hasProAccess: hasProAccess,
+                    onUpgrade: handleUpgradeTapped
+                )
+                .tag(WidgetPreviewPage.combinedMedium)
             }
             .padding(.top, -40)
             .padding(.bottom, -8)
@@ -86,10 +100,11 @@ struct WidgetPreview: View {
 
 #Preview {
     @State var channel: YouTubeChannel = .preview
-    return WidgetPreview(channel: $channel)
+    @State var currentPage: WidgetPreviewPage = .subscribersSmall
+    return WidgetPreview(channel: $channel, currentPage: $currentPage)
 }
 
-private struct LockedPreview<Content: View>: View {
+struct LockedPreview<Content: View>: View {
     let size: WidgetSize
     let isLocked: Bool
     let onUpgrade: () -> Void

--- a/SubscriberWidget/View/CustomizeWidgetView/WidgetShareRenderer.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/WidgetShareRenderer.swift
@@ -1,0 +1,99 @@
+//
+//  WidgetShareRenderer.swift
+//  SubscriberWidget
+//
+//  Created by Codex on 2025-02-14.
+//
+
+import SwiftUI
+import UIKit
+
+enum WidgetShareRendererError: LocalizedError {
+    case imageGenerationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .imageGenerationFailed:
+            return "Could not generate the widget image."
+        }
+    }
+}
+
+@MainActor
+struct WidgetShareRenderer {
+    func renderImage(
+        channel: YouTubeChannel,
+        page: WidgetPreviewPage,
+        hasProAccess: Bool,
+        colorScheme: ColorScheme,
+        configuration: ShareCardConfiguration
+    ) async throws -> UIImage {
+        let previewImage = await loadImage(from: channel.profileImage)
+        let view = ShareableWidgetCard(
+            channel: channel,
+            page: page,
+            channelImage: previewImage,
+            hasProAccess: hasProAccess,
+            configuration: configuration
+        )
+        .environment(\.colorScheme, colorScheme)
+        .frame(
+            width: ShareableWidgetCard.canvasSize.width,
+            height: ShareableWidgetCard.canvasSize.height
+        )
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 1
+
+        guard let image = renderer.uiImage else {
+            throw WidgetShareRendererError.imageGenerationFailed
+        }
+
+        return image
+    }
+
+    func render(
+        channel: YouTubeChannel,
+        page: WidgetPreviewPage,
+        hasProAccess: Bool,
+        colorScheme: ColorScheme,
+        configuration: ShareCardConfiguration
+    ) async throws -> URL {
+        let image = try await renderImage(
+            channel: channel,
+            page: page,
+            hasProAccess: hasProAccess,
+            colorScheme: colorScheme,
+            configuration: configuration
+        )
+
+        guard let pngData = image.pngData() else {
+            throw WidgetShareRendererError.imageGenerationFailed
+        }
+
+        let sanitizedName = channel.channelName
+            .lowercased()
+            .replacingOccurrences(of: " ", with: "-")
+            .filter(\.isASCII)
+        let fileName = "subwidget-\(sanitizedName)-\(page.analyticsName).png"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+
+        if FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.removeItem(at: url)
+        }
+
+        try pngData.write(to: url)
+        return url
+    }
+
+    private func loadImage(from urlString: String) async -> UIImage? {
+        guard let url = URL(string: urlString) else { return nil }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return UIImage(data: data)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/SubscriberWidget/View/CustomizeWidgetView/WidgetShareRenderer.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/WidgetShareRenderer.swift
@@ -71,10 +71,7 @@ struct WidgetShareRenderer {
             throw WidgetShareRendererError.imageGenerationFailed
         }
 
-        let sanitizedName = channel.channelName
-            .lowercased()
-            .replacingOccurrences(of: " ", with: "-")
-            .filter(\.isASCII)
+        let sanitizedName = sanitizeFilenameComponent(channel.channelName)
         let fileName = "subwidget-\(sanitizedName)-\(page.analyticsName).png"
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
 
@@ -95,5 +92,30 @@ struct WidgetShareRenderer {
         } catch {
             return nil
         }
+    }
+
+    private func sanitizeFilenameComponent(_ input: String) -> String {
+        let sanitized = input
+            .lowercased()
+            .map { character -> Character in
+                if character.isASCII, character.isLetter || character.isNumber {
+                    return character
+                }
+
+                if character == "-" || character == "_" {
+                    return character
+                }
+
+                return "-"
+            }
+            .reduce(into: "") { result, character in
+                if character == "-", result.last == "-" {
+                    return
+                }
+                result.append(character)
+            }
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-_"))
+
+        return sanitized.isEmpty ? "channel" : sanitized
     }
 }

--- a/SubscriberWidget/View/CustomizeWidgetView/WidgetShareRenderer.swift
+++ b/SubscriberWidget/View/CustomizeWidgetView/WidgetShareRenderer.swift
@@ -21,6 +21,8 @@ enum WidgetShareRendererError: LocalizedError {
 
 @MainActor
 struct WidgetShareRenderer {
+    private static let imageCache = NSCache<NSString, UIImage>()
+
     func renderImage(
         channel: YouTubeChannel,
         page: WidgetPreviewPage,
@@ -84,11 +86,17 @@ struct WidgetShareRenderer {
     }
 
     private func loadImage(from urlString: String) async -> UIImage? {
+        if let cachedImage = Self.imageCache.object(forKey: urlString as NSString) {
+            return cachedImage
+        }
+
         guard let url = URL(string: urlString) else { return nil }
 
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
-            return UIImage(data: data)
+            guard let image = UIImage(data: data) else { return nil }
+            Self.imageCache.setObject(image, forKey: urlString as NSString)
+            return image
         } catch {
             return nil
         }


### PR DESCRIPTION
## Summary
- add a dedicated share editor from the customize widget screen
- generate polished square share assets with configurable backgrounds, zoom, shadow, glow, and border controls
- gate locked widget sharing behind Pro and add analytics/localization support for the new flow

## What Changed
- added a share editor sheet with live preview, background selection, zoom/shadow controls, glow/border toggles, and native share-sheet handoff
- added share asset rendering infrastructure and reusable shareable widget/card views
- updated widget preview state management so the selected preview variant flows into sharing
- adjusted exported widget rendering to hide refresh UI and use stable entry images
- added background-selection/share analytics and localized the new share strings

## Notes
- not compiled or runtime-tested in this PR flow
- non-Pro users now hit the paywall immediately when attempting to share a locked widget variant
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arjun-dureja/subwidget/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
