### PR TITLE
Fix legacy user widget paywall gating

### DIFF
--- a/SubscriberCount/SubWidgetIntentTimelineProvider.swift
+++ b/SubscriberCount/SubWidgetIntentTimelineProvider.swift
@@ -209,6 +209,11 @@ struct SubscriberCountEntryView: View {
     var entry: SubWidgetIntentTimelineProvider.Entry
     @Environment(\.widgetFamily) private var widgetFamily
     @AppStorage("hasProAccess", store: .shared) private var hasProAccess: Bool = false
+    @AppStorage("isLegacyUser", store: .shared) private var isLegacyUser: Bool = false
+
+    private var hasEffectiveProAccess: Bool {
+        hasProAccess || isLegacyUser
+    }
 
     private var isPreview: Bool {
         entry.channel?.channelName == "SubWidgetPrev"
@@ -216,7 +221,7 @@ struct SubscriberCountEntryView: View {
 
     private var isLocked: Bool {
         guard entry.channel != nil else { return false }
-        guard !hasProAccess else { return false }
+        guard !hasEffectiveProAccess else { return false }
         guard !isPreview else { return false }
         return isProOnlyWidgetKind
     }
@@ -237,7 +242,7 @@ struct SubscriberCountEntryView: View {
     }
 
     private var deepLink: URL? {
-        if !hasProAccess {
+        if !hasEffectiveProAccess {
             return WidgetDeepLink.paywall(source: isProOnlyWidgetKind ? "widget_locked" : "widget_free")
         }
 

--- a/SubscriberCount/SubWidgetIntentTimelineProvider.swift
+++ b/SubscriberCount/SubWidgetIntentTimelineProvider.swift
@@ -209,11 +209,6 @@ struct SubscriberCountEntryView: View {
     var entry: SubWidgetIntentTimelineProvider.Entry
     @Environment(\.widgetFamily) private var widgetFamily
     @AppStorage("hasProAccess", store: .shared) private var hasProAccess: Bool = false
-    @AppStorage("isLegacyUser", store: .shared) private var isLegacyUser: Bool = false
-
-    private var hasEffectiveProAccess: Bool {
-        hasProAccess || isLegacyUser
-    }
 
     private var isPreview: Bool {
         entry.channel?.channelName == "SubWidgetPrev"
@@ -221,7 +216,7 @@ struct SubscriberCountEntryView: View {
 
     private var isLocked: Bool {
         guard entry.channel != nil else { return false }
-        guard !hasEffectiveProAccess else { return false }
+        guard !hasProAccess else { return false }
         guard !isPreview else { return false }
         return isProOnlyWidgetKind
     }
@@ -242,7 +237,7 @@ struct SubscriberCountEntryView: View {
     }
 
     private var deepLink: URL? {
-        if !hasEffectiveProAccess {
+        if !hasProAccess {
             return WidgetDeepLink.paywall(source: isProOnlyWidgetKind ? "widget_locked" : "widget_free")
         }
 

--- a/SubscriberWidget/Services/SubscriptionService.swift
+++ b/SubscriberWidget/Services/SubscriptionService.swift
@@ -26,7 +26,7 @@ class SubscriptionService: SubscriptionServiceProtocol {
     @AppStorage("hasProAccess", store: .shared) var hasProAccess: Bool = false
     @AppStorage("isLegacyUser", store: .shared) var isLegacyUser: Bool = false
 
-    func checkAccess() async {
+    func checkAccess() async -> AccessState {
         if isLegacyUser {
             hasProAccess = true
             AnalyticsService.shared.logSubscriptionAccessEvaluated(
@@ -34,7 +34,7 @@ class SubscriptionService: SubscriptionServiceProtocol {
                 hasProAccess: true,
                 isLegacyUser: true
             )
-            return
+            return AccessState(hasProAccess: true, isLegacyUser: true)
         }
 
         if await detectLegacyUser() {
@@ -46,7 +46,7 @@ class SubscriptionService: SubscriptionServiceProtocol {
                 hasProAccess: true,
                 isLegacyUser: true
             )
-            return
+            return AccessState(hasProAccess: true, isLegacyUser: true)
         }
 
         let isProActive = await checkRevenueCatEntitlement()
@@ -59,6 +59,7 @@ class SubscriptionService: SubscriptionServiceProtocol {
             hasProAccess: isProActive,
             isLegacyUser: false
         )
+        return AccessState(hasProAccess: isProActive, isLegacyUser: false)
     }
 
     /// Checks if user purchased the app before it went freemium

--- a/SubscriberWidget/Services/SubscriptionServiceProtocol.swift
+++ b/SubscriberWidget/Services/SubscriptionServiceProtocol.swift
@@ -15,8 +15,4 @@ protocol SubscriptionServiceProtocol {
 struct AccessState {
     let hasProAccess: Bool
     let isLegacyUser: Bool
-
-    var hasEffectiveProAccess: Bool {
-        hasProAccess || isLegacyUser
-    }
 }

--- a/SubscriberWidget/Services/SubscriptionServiceProtocol.swift
+++ b/SubscriberWidget/Services/SubscriptionServiceProtocol.swift
@@ -9,5 +9,14 @@
 protocol SubscriptionServiceProtocol {
     var hasProAccess: Bool { get set }
 
-    func checkAccess() async
+    func checkAccess() async -> AccessState
+}
+
+struct AccessState {
+    let hasProAccess: Bool
+    let isLegacyUser: Bool
+
+    var hasEffectiveProAccess: Bool {
+        hasProAccess || isLegacyUser
+    }
 }

--- a/SubscriberWidget/View/MainView.swift
+++ b/SubscriberWidget/View/MainView.swift
@@ -29,12 +29,7 @@ struct MainView: View {
     @AppStorage("pendingPaywallFromWidget", store: .shared) private var pendingPaywallFromWidget: Bool = false
     @AppStorage("pendingWidgetPaywallSource", store: .shared) private var pendingWidgetPaywallSource: String = "widget_legacy"
     @AppStorage("hasProAccess", store: .shared) private var hasProAccess: Bool = false
-    @AppStorage("isLegacyUser", store: .shared) private var isLegacyUser: Bool = false
     @AppStorage("hasCompletedOnboarding", store: .shared) private var hasCompletedOnboarding: Bool = false
-
-    private var hasEffectiveProAccess: Bool {
-        hasProAccess || isLegacyUser
-    }
 
     init() {
         WishKit.configure(with: Constants.wishKitApiKey)
@@ -137,8 +132,8 @@ struct MainView: View {
     @MainActor
     private func handleWidgetPaywallRequest(source: String) {
         Task {
-            await SubscriptionService().checkAccess()
-            guard !hasEffectiveProAccess else { return }
+            let accessState = await SubscriptionService().checkAccess()
+            guard !accessState.hasEffectiveProAccess else { return }
 
             if source == "widget_locked" || source == "widget_legacy" {
                 AnalyticsService.shared.logPaywallShown(source: source)
@@ -162,10 +157,10 @@ struct MainView: View {
         guard !hasPreparedInitialPresentation else { return }
         hasPreparedInitialPresentation = true
 
-        await SubscriptionService().checkAccess()
+        let accessState = await SubscriptionService().checkAccess()
         let hasSavedChannels = !ChannelStorageService().getChannels().isEmpty
 
-        guard !hasEffectiveProAccess else {
+        guard !accessState.hasEffectiveProAccess else {
             hasCompletedOnboarding = true
             return
         }

--- a/SubscriberWidget/View/MainView.swift
+++ b/SubscriberWidget/View/MainView.swift
@@ -133,7 +133,7 @@ struct MainView: View {
     private func handleWidgetPaywallRequest(source: String) {
         Task {
             let accessState = await SubscriptionService().checkAccess()
-            guard !accessState.hasEffectiveProAccess else { return }
+            guard !accessState.hasProAccess else { return }
 
             if source == "widget_locked" || source == "widget_legacy" {
                 AnalyticsService.shared.logPaywallShown(source: source)
@@ -160,7 +160,7 @@ struct MainView: View {
         let accessState = await SubscriptionService().checkAccess()
         let hasSavedChannels = !ChannelStorageService().getChannels().isEmpty
 
-        guard !accessState.hasEffectiveProAccess else {
+        guard !accessState.hasProAccess else {
             hasCompletedOnboarding = true
             return
         }

--- a/SubscriberWidget/View/MainView.swift
+++ b/SubscriberWidget/View/MainView.swift
@@ -29,7 +29,12 @@ struct MainView: View {
     @AppStorage("pendingPaywallFromWidget", store: .shared) private var pendingPaywallFromWidget: Bool = false
     @AppStorage("pendingWidgetPaywallSource", store: .shared) private var pendingWidgetPaywallSource: String = "widget_legacy"
     @AppStorage("hasProAccess", store: .shared) private var hasProAccess: Bool = false
+    @AppStorage("isLegacyUser", store: .shared) private var isLegacyUser: Bool = false
     @AppStorage("hasCompletedOnboarding", store: .shared) private var hasCompletedOnboarding: Bool = false
+
+    private var hasEffectiveProAccess: Bool {
+        hasProAccess || isLegacyUser
+    }
 
     init() {
         WishKit.configure(with: Constants.wishKitApiKey)
@@ -133,17 +138,17 @@ struct MainView: View {
     private func handleWidgetPaywallRequest(source: String) {
         Task {
             await SubscriptionService().checkAccess()
-            if !hasProAccess {
-                if source == "widget_locked" || source == "widget_legacy" {
-                    AnalyticsService.shared.logPaywallShown(source: source)
-                    showPaywall = true
-                    return
-                }
+            guard !hasEffectiveProAccess else { return }
 
-                widgetPaywallSource = source
-                AnalyticsService.shared.logWidgetUpgradeAlertShown(source: source)
-                showWidgetUpgradeAlert = true
+            if source == "widget_locked" || source == "widget_legacy" {
+                AnalyticsService.shared.logPaywallShown(source: source)
+                showPaywall = true
+                return
             }
+
+            widgetPaywallSource = source
+            AnalyticsService.shared.logWidgetUpgradeAlertShown(source: source)
+            showWidgetUpgradeAlert = true
         }
     }
 
@@ -160,7 +165,7 @@ struct MainView: View {
         await SubscriptionService().checkAccess()
         let hasSavedChannels = !ChannelStorageService().getChannels().isEmpty
 
-        guard !hasProAccess else {
+        guard !hasEffectiveProAccess else {
             hasCompletedOnboarding = true
             return
         }

--- a/SubscriberWidget/View/View+Extensions.swift
+++ b/SubscriberWidget/View/View+Extensions.swift
@@ -26,11 +26,11 @@ extension View {
                     }
                     .onPurchaseCompleted { _, _ in
                         AnalyticsService.shared.logSubscriptionPurchaseCompleted()
-                        Task { await SubscriptionService().checkAccess() }
+                        Task { _ = await SubscriptionService().checkAccess() }
                         NotificationCenter.default.post(name: .revenueCatPurchaseCompleted, object: nil)
                     }
                     .onRestoreCompleted { customerInfo in
-                        Task { await SubscriptionService().checkAccess() }
+                        Task { _ = await SubscriptionService().checkAccess() }
                         if customerInfo.entitlements[Constants.revenueCatEntitlementId]?.isActive ?? false {
                             AnalyticsService.shared.logSubscriptionRestoreSucceeded()
                             NotificationCenter.default.post(name: .revenueCatPurchaseCompleted, object: nil)

--- a/SubscriberWidget/ViewModel/ViewModel.swift
+++ b/SubscriberWidget/ViewModel/ViewModel.swift
@@ -51,7 +51,7 @@ class ViewModel: ObservableObject {
             state = .loading
 
             // Check subscription/legacy access first
-            await subscriptionService.checkAccess()
+            _ = await subscriptionService.checkAccess()
 
             channels = try await getChannelsWithUpdatedStatistics()
             AnalyticsService.shared.logChannelsLoaded(channels.count, channels.map({ $0.channelName }))


### PR DESCRIPTION
## Summary
- treat legacy users as having effective Pro access in widget lock and deep-link gating
- prevent widget-triggered paywalls and onboarding from showing for legacy users in the main app flow
- align widget cold-start handling with the same effective access check

## Why
Legacy users should never be sent through widget paywall flows. The widget path was only trusting `hasProAccess`, while legacy access is discovered and persisted separately via `isLegacyUser`.

## Testing
- Not run (not compiled per request)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arjun-dureja/subwidget/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
