### PR TITLE
Fix widget offline fallback and auto-open configuration

### DIFF
--- a/SubscriberCount/CombinedCountWidget.swift
+++ b/SubscriberCount/CombinedCountWidget.swift
@@ -23,6 +23,7 @@ struct CombinedCount: Widget {
         )
         .configurationDisplayName("Subscribers + Views")
         .description("View both your subscriber and view counts in one widget")
+        .promptsForUserConfiguration()
         .supportedFamilies([.systemMedium])
     }
 }

--- a/SubscriberCount/SubWidgetIntentTimelineProvider.swift
+++ b/SubscriberCount/SubWidgetIntentTimelineProvider.swift
@@ -120,38 +120,66 @@ struct SubWidgetIntentTimelineProvider: AppIntentTimelineProvider {
         for channelEntity: YouTubeChannelParam?,
         channelStorageService: ChannelStorageService
     ) async -> SimpleEntry {
+        guard let id = channelEntity?.identifier else {
+            AnalyticsService.shared.logWidgetChannelFetchFailed(SubWidgetError.invalidIdentifer.localizedDescription)
+            return SimpleEntry(
+                channel: nil,
+                widgetType: widgetType
+            )
+        }
+
+        let channels = channelStorageService.getChannels()
+        guard let channel = channels.first(where: { $0.id == id }) else {
+            AnalyticsService.shared.logWidgetChannelFetchFailed(SubWidgetError.channelNotfound.localizedDescription)
+            return SimpleEntry(
+                channel: nil,
+                widgetType: widgetType
+            )
+        }
+
         do {
-            guard let id = channelEntity?.identifier else {
-                throw SubWidgetError.invalidIdentifer
+            let youtubeService = YouTubeService()
+            var updatedChannel = try await youtubeService.getChannelDetailsFromId(for: channel.channelId)
+            updatedChannel.id = channel.id
+            updatedChannel.bgColor = channel.bgColor
+            updatedChannel.accentColor = channel.accentColor
+            updatedChannel.numberColor = channel.numberColor
+            updatedChannel.milestoneEnabled = channel.milestoneEnabled
+
+            if channel.milestoneEnabled {
+                await MilestoneNotificationService.shared.checkAndNotifyMilestone(channel: updatedChannel)
             }
 
-            let channels = channelStorageService.getChannels()
-            if let channel = channels.first(where: { $0.id == id }) {
-                let youtubeService = YouTubeService()
-                var updatedChannel = try await youtubeService.getChannelDetailsFromId(for: channel.channelId)
-                updatedChannel.bgColor = channel.bgColor
-                updatedChannel.accentColor = channel.accentColor
-                updatedChannel.numberColor = channel.numberColor
-                updatedChannel.milestoneEnabled = channel.milestoneEnabled
+            persist(updatedChannel, in: channels, with: channelStorageService)
 
-                if channel.milestoneEnabled {
-                    await MilestoneNotificationService.shared.checkAndNotifyMilestone(channel: updatedChannel)
-                }
-
-                return SimpleEntry(
-                    channel: updatedChannel,
-                    channelImage: await getImageForUrl(updatedChannel.profileImage),
-                    widgetType: widgetType
-                )
-            }
+            return SimpleEntry(
+                channel: updatedChannel,
+                channelImage: await getImageForUrl(updatedChannel.profileImage),
+                widgetType: widgetType
+            )
         } catch {
             AnalyticsService.shared.logWidgetChannelFetchFailed(error.localizedDescription)
         }
 
         return SimpleEntry(
-            channel: nil,
+            channel: channel,
+            channelImage: await getImageForUrl(channel.profileImage),
             widgetType: widgetType
         )
+    }
+
+    private func persist(
+        _ updatedChannel: YouTubeChannel,
+        in channels: [YouTubeChannel],
+        with channelStorageService: ChannelStorageService
+    ) {
+        var updatedChannels = channels
+        guard let index = updatedChannels.firstIndex(where: { $0.id == updatedChannel.id }) else {
+            return
+        }
+
+        updatedChannels[index] = updatedChannel
+        channelStorageService.saveChannels(updatedChannels)
     }
 
     private func getImageForUrl(_ urlString: String) async -> UIImage {

--- a/SubscriberCount/SubWidgetIntentTimelineProvider.swift
+++ b/SubscriberCount/SubWidgetIntentTimelineProvider.swift
@@ -19,15 +19,18 @@ struct SimpleEntry: TimelineEntry {
     let channel: YouTubeChannel?
     let channelImage: UIImage
     let widgetType: WidgetType
+    let shouldRetrySoon: Bool
 
     init(
         channel: YouTubeChannel?,
         channelImage: UIImage = UIImage(systemName: "person.circle")!,
-        widgetType: WidgetType
+        widgetType: WidgetType,
+        shouldRetrySoon: Bool = false
     ) {
         self.channel = channel
         self.channelImage = channelImage
         self.widgetType = widgetType
+        self.shouldRetrySoon = shouldRetrySoon
     }
 }
 
@@ -109,7 +112,7 @@ struct SubWidgetIntentTimelineProvider: AppIntentTimelineProvider {
 
             return Timeline(
                 entries: [result],
-                policy: result.channel == nil
+                policy: result.shouldRetrySoon
                     ? retryPolicy
                     : .after(.now.advanced(by: refreshFrequency * 60))
             )
@@ -124,7 +127,8 @@ struct SubWidgetIntentTimelineProvider: AppIntentTimelineProvider {
             AnalyticsService.shared.logWidgetChannelFetchFailed(SubWidgetError.invalidIdentifer.localizedDescription)
             return SimpleEntry(
                 channel: nil,
-                widgetType: widgetType
+                widgetType: widgetType,
+                shouldRetrySoon: true
             )
         }
 
@@ -133,7 +137,8 @@ struct SubWidgetIntentTimelineProvider: AppIntentTimelineProvider {
             AnalyticsService.shared.logWidgetChannelFetchFailed(SubWidgetError.channelNotfound.localizedDescription)
             return SimpleEntry(
                 channel: nil,
-                widgetType: widgetType
+                widgetType: widgetType,
+                shouldRetrySoon: true
             )
         }
 
@@ -150,7 +155,7 @@ struct SubWidgetIntentTimelineProvider: AppIntentTimelineProvider {
                 await MilestoneNotificationService.shared.checkAndNotifyMilestone(channel: updatedChannel)
             }
 
-            persist(updatedChannel, in: channels, with: channelStorageService)
+            persist(updatedChannel, with: channelStorageService)
 
             return SimpleEntry(
                 channel: updatedChannel,
@@ -164,16 +169,16 @@ struct SubWidgetIntentTimelineProvider: AppIntentTimelineProvider {
         return SimpleEntry(
             channel: channel,
             channelImage: await getImageForUrl(channel.profileImage),
-            widgetType: widgetType
+            widgetType: widgetType,
+            shouldRetrySoon: true
         )
     }
 
     private func persist(
         _ updatedChannel: YouTubeChannel,
-        in channels: [YouTubeChannel],
         with channelStorageService: ChannelStorageService
     ) {
-        var updatedChannels = channels
+        var updatedChannels = channelStorageService.getChannels()
         guard let index = updatedChannels.firstIndex(where: { $0.id == updatedChannel.id }) else {
             return
         }

--- a/SubscriberCount/SubscriberCountWidget.swift
+++ b/SubscriberCount/SubscriberCountWidget.swift
@@ -24,6 +24,7 @@ struct SubscriberCount: Widget {
         )
         .configurationDisplayName("Subscriber Count")
         .description("View your YouTube subscriber count in realtime")
+        .promptsForUserConfiguration()
         .supportedFamilies([.accessoryRectangular, .systemSmall, .systemMedium])
     }
 }

--- a/SubscriberCount/ViewCountWidget.swift
+++ b/SubscriberCount/ViewCountWidget.swift
@@ -24,6 +24,7 @@ struct ViewCount: Widget {
         )
         .configurationDisplayName("View Count")
         .description("View your YouTube view count in realtime")
+        .promptsForUserConfiguration()
         .supportedFamilies([.accessoryRectangular, .systemSmall, .systemMedium])
     }
 }


### PR DESCRIPTION
## Summary
- keep configured widgets rendering their last known channel data when a refresh fails offline
- persist successful widget refreshes back into shared storage so offline fallbacks stay current
- automatically present the widget configuration UI after a widget is added to the Home Screen

## Problem
Configured widgets were falling back to the unconfigured "Select Your Channel" state whenever the device lost network access during a timeline refresh. That is inaccurate because the widget configuration is still valid.

The widget setup flow also required users to manually long-press and edit a newly added widget before they could choose a channel.

## Solution
- Change the timeline provider to resolve the selected channel from shared storage before fetching
- On successful fetch, merge the fresh YouTube stats with the saved widget customization values and write that channel back to shared storage
- On fetch failure, return the stored channel instead of `nil` so the widget stays in a stale-but-correct state
- Add `.promptsForUserConfiguration()` to each widget configuration so iOS opens the config sheet immediately after placement

## User Impact
- widgets no longer look unconfigured when the device is offline
- users see the last known subscriber/view counts until connectivity returns
- new widgets can be configured immediately after being placed on the Home Screen

## Testing
- not fully validated with a successful `xcodebuild`; the repo currently fails builds due to a pre-existing duplicate `IntentDefinitionCompile` task for `SubscriberCount.intentdefinition`
- logic reviewed locally and changes are scoped to the widget provider and widget configuration declarations

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arjun-dureja/subwidget/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->