### PR TITLE
Integrate Kickstart Exchange banner

### DIFF
--- a/SubscriberWidget.xcodeproj/project.pbxproj
+++ b/SubscriberWidget.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A65D1A6E10694118ADE020B5 /* KickstartExchange in Frameworks */ = {isa = PBXBuildFile; productRef = 3297276CFAC44068A5668ECE /* KickstartExchange */; };
 		7209656C2F65E6A700A1376E /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 720A6A6F2F5E8CD7007AD287 /* RevenueCat */; };
 		722E2E852B65F86B00E4832E /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = 722E2E842B65F86B00E4832E /* Mixpanel */; };
 		722E2E8C2B65FDFC00E4832E /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = 722E2E8B2B65FDFC00E4832E /* Mixpanel */; };
@@ -137,6 +138,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A65D1A6E10694118ADE020B5 /* KickstartExchange in Frameworks */,
 				72AFB3CC2F30722300C4774A /* ConfettiSwiftUI in Frameworks */,
 				72AFB3BF2F30231400C4774A /* RevenueCat in Frameworks */,
 				7247B03F2F42792A008A8DF0 /* FacebookCore in Frameworks */,
@@ -229,6 +231,7 @@
 			);
 			name = SubscriberWidget;
 			packageProductDependencies = (
+				3297276CFAC44068A5668ECE /* KickstartExchange */,
 				724BD9292AB4063A008C1DB2 /* Cache */,
 				72F2EE212B2D6128002AFCEA /* WishKit */,
 				722E2E842B65F86B00E4832E /* Mixpanel */,
@@ -281,6 +284,7 @@
 			);
 			mainGroup = 7292FFF9251D1F3D0050194B;
 			packageReferences = (
+				A83BC57C36D94A48925DA2CF /* XCRemoteSwiftPackageReference "KickstartSDK" */,
 				724BD9282AB4063A008C1DB2 /* XCRemoteSwiftPackageReference "Cache" */,
 				72F2EE202B2D605A002AFCEA /* XCRemoteSwiftPackageReference "wishkit-ios" */,
 				722E2E832B65F86B00E4832E /* XCRemoteSwiftPackageReference "mixpanel-swift" */,
@@ -644,6 +648,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		A83BC57C36D94A48925DA2CF /* XCRemoteSwiftPackageReference "KickstartSDK" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/twostraws/KickstartSDK";
+			requirement = {
+				kind = exactVersion;
+				version = 0.5.0;
+			};
+		};
 		722E2E832B65F86B00E4832E /* XCRemoteSwiftPackageReference "mixpanel-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mixpanel/mixpanel-swift";
@@ -695,6 +707,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		3297276CFAC44068A5668ECE /* KickstartExchange */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A83BC57C36D94A48925DA2CF /* XCRemoteSwiftPackageReference "KickstartSDK" */;
+			productName = KickstartExchange;
+		};
 		720A6A6F2F5E8CD7007AD287 /* RevenueCat */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 72AFB3BD2F30231400C4774A /* XCRemoteSwiftPackageReference "purchases-ios-spm" */;

--- a/SubscriberWidget.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SubscriberWidget.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2fbe82f03b1616215c9e99fa7366816c684f2b37691498d81de67035b4526dcb",
+  "originHash" : "cc997941f6ee055088e5a1571613ebbbafe58363c836f8fee9f904fddd59176a",
   "pins" : [
     {
       "identity" : "cache",
@@ -25,6 +25,15 @@
       "state" : {
         "revision" : "c19607d535864533523d1f437c84035e5fb101cf",
         "version" : "14.1.0"
+      }
+    },
+    {
+      "identity" : "kickstartsdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/twostraws/KickstartSDK",
+      "state" : {
+        "revision" : "36f475be3e28e335d5c8733e08cef15e7cf774b9",
+        "version" : "0.5.0"
       }
     },
     {

--- a/SubscriberWidget/View/SettingsView/SettingsView.swift
+++ b/SubscriberWidget/View/SettingsView/SettingsView.swift
@@ -6,8 +6,9 @@
 //  Copyright © 2021 Arjun Dureja. All rights reserved.
 //
 
-import SwiftUI
+import KickstartExchange
 import StoreKit
+import SwiftUI
 import WidgetKit
 
 struct SettingsView: View {
@@ -37,34 +38,40 @@ struct SettingsView: View {
 
                 Form {
                     Section(footer: EmptyView()) {
-                        HStack(spacing: 16) {
-                            Spacer()
-                            ZStack(alignment: .topTrailing) {
-                                AppIcon()
-                                    .cornerRadius(16)
-                                    .frame(width: 60, height: 60)
+                        VStack(spacing: 24) {
+                            if !hasProAccess {
+                                ExchangeBannerAdView(apiKey: "ks_live_1QHlZ6UVasvjtB7uUQPCe5NKy1Bz3Udgdks5uiGIkx0")
+                            }
 
-                                if hasProAccess {
-                                    Text("PRO")
-                                        .font(.system(size: 12, weight: .bold))
-                                        .foregroundColor(.black)
-                                        .padding(4)
-                                        .background(Color.gold.cornerRadius(8))
-                                        .offset(x: 12, y: -12)
+                            HStack(spacing: 16) {
+                                Spacer()
+                                ZStack(alignment: .topTrailing) {
+                                    AppIcon()
+                                        .cornerRadius(16)
+                                        .frame(width: 60, height: 60)
+
+                                    if hasProAccess {
+                                        Text("PRO")
+                                            .font(.system(size: 12, weight: .bold))
+                                            .foregroundColor(.black)
+                                            .padding(4)
+                                            .background(Color.gold.cornerRadius(8))
+                                            .offset(x: 12, y: -12)
+                                    }
                                 }
-                            }
 
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("SubWidget \(Bundle.main.appVersion)")
-                                    .font(.system(size: 16, weight: .medium))
-                                Text("by Arjun Dureja")
-                                    .font(.system(size: 14))
-                                    .foregroundColor(colorScheme == .dark ? .darkModeTitleGray2 : .titleGray)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("SubWidget \(Bundle.main.appVersion)")
+                                        .font(.system(size: 16, weight: .medium))
+                                    Text("by Arjun Dureja")
+                                        .font(.system(size: 14))
+                                        .foregroundColor(colorScheme == .dark ? .darkModeTitleGray2 : .titleGray)
+                                }
+                                Spacer()
                             }
-                            Spacer()
                         }
                     }
-                    .padding(.top, 24)
+                    .padding(.top, hasProAccess ? 24 : 0)
                     .listRowBackground(Color.clear)
 
                     if !hasProAccess {

--- a/SubscriberWidget/View/SettingsView/SettingsView.swift
+++ b/SubscriberWidget/View/SettingsView/SettingsView.swift
@@ -40,7 +40,7 @@ struct SettingsView: View {
                     Section(footer: EmptyView()) {
                         VStack(spacing: 24) {
                             if !hasProAccess {
-                                ExchangeBannerAdView(apiKey: "ks_live_1QHlZ6UVasvjtB7uUQPCe5NKy1Bz3Udgdks5uiGIkx0")
+                                ExchangeBannerAdView(apiKey: Constants.kickstartExchangeApiKey)
                             }
 
                             HStack(spacing: 16) {


### PR DESCRIPTION
## Summary

- Add KickstartSDK at the verified 0.5.0 tag and link KickstartExchange only to the main app target.
- Show the Exchange banner at the top of Settings only for FREE users.
- Keep PRO users ad-free using the existing entitlement state.
- Use 24 points between the banner and the existing app header without resizing or restyling the SDK view.
- Add no tracker, device identifier, or extra third-party dependency.

## Verification

- Swift package dependency resolution succeeded.
- Debug builds succeeded, including a signed iPhone device build.
- Installed and launched successfully on an iPhone 15 Pro.
- SwiftLint completed with four existing warnings in untouched files and no serious violations.

## Manual release steps

- In App Store Connect, disclose Usage Data: Product Interaction and Advertising Data for Third-Party Advertising, Developer Advertising or Marketing, Analytics, and App Functionality. Mark both data types as unlinked from identity and not used for tracking, while preserving all existing disclosures.
- Update the hosted app privacy policy to mention Kickstart Exchange and link to its privacy notice.